### PR TITLE
Add start time and end time filters to internal API

### DIFF
--- a/parkings/api/internal/parking.py
+++ b/parkings/api/internal/parking.py
@@ -23,10 +23,14 @@ class InternalAPIParkingSerializer(serializers.ModelSerializer):
 class InternalAPIParkingFilter(django_filters.rest_framework.FilterSet):
     status = django_filters.CharFilter(method='filter_status')
     registration_number = django_filters.CharFilter()
+    time_start_gte = django_filters.DateTimeFilter(name='time_start', lookup_expr='gte')
+    time_start_lte = django_filters.DateTimeFilter(name='time_start', lookup_expr='lte')
+    time_end_gte = django_filters.DateTimeFilter(name='time_end', lookup_expr='gte')
+    time_end_lte = django_filters.DateTimeFilter(name='time_end', lookup_expr='lte')
 
     class Meta:
         model = Parking
-        fields = ('status',)
+        fields = ('status', 'registration_number', 'time_start_gte', 'time_start_lte', 'time_end_gte', 'time_end_lte')
 
     def filter_status(self, queryset, name, value):
         now = timezone.now()


### PR DESCRIPTION
Both times allow filtering in both directions, ie. the actual filter are
time_start_gte, time_start_lte, time_end_gte and time_end_lte.