### PR TITLE
Api error codes

### DIFF
--- a/docs/api/operator.yaml
+++ b/docs/api/operator.yaml
@@ -164,7 +164,13 @@ paths:
           schema:
             type: object
             example:
-              time_end: 2016-12-25T22:00:00Z
+              location:
+                type: Point
+                coordinates: [60.170014, 24.938466]
+              registration_number: LOL-007
+              time_start: 2016-12-24T21:00:00Z
+              time_end: 2016-12-24T22:00:00Z
+              zone: 2
             properties:
               location:
                 $ref: '#/definitions/Location'
@@ -220,13 +226,7 @@ paths:
           schema:
             type: object
             example:
-              location:
-                type: Point
-                coordinates: [60.170014, 24.938466]
-              registration_number: LOL-007
-              time_start: 2016-12-24T21:00:00Z
-              time_end: 2016-12-24T22:00:00Z
-              zone: 2
+              time_end: 2016-12-25T22:00:00Z
             properties:
               location:
                 $ref: '#/definitions/Location'
@@ -250,6 +250,8 @@ paths:
           description: The parking was updated successfully
           schema:
             $ref: '#/definitions/Parking'
+        400:
+          $ref: '#/responses/BadRequest'
         401:
           $ref: '#/responses/Unauthorized'
         403:
@@ -351,25 +353,26 @@ definitions:
         items:
           type: number
           format: float
-  ErrorResponse:
-    type: object
-    properties:
-      detail:
-        type: string
 responses:
   BadRequest:
     description: Bad request, details in request body
     schema:
-      $ref: '#/definitions/ErrorResponse'
+      example:
+        registration_number: [Enter a valid value.]
   Unauthorized:
     description: Unauthorized access
-    schema:
-      $ref: '#/definitions/ErrorResponse'
   Forbidden:
-    description: No permission, or the 2 min grace period for editing has passed
+    description: Forbidden request
     schema:
-      $ref: '#/definitions/ErrorResponse'
+      type: object
+      properties:
+        code:
+          type: string
+          enum: [unknown_error, permission_denied, grace_period_over]
+        detail:
+          type: string
+      example:
+        code: grace_period_over
+        detail: Grace period has passed. Only "time_end" can be updated via PATCH.
   NotFound:
     description: Parking not found
-    schema:
-      $ref: '#/definitions/ErrorResponse'

--- a/parkings/api/common.py
+++ b/parkings/api/common.py
@@ -1,6 +1,7 @@
 import django_filters
 from django.utils import timezone
-from rest_framework import serializers
+from django.utils.translation import ugettext_lazy as _
+from rest_framework import exceptions, serializers
 
 from parkings.models import Address, Parking
 
@@ -36,3 +37,9 @@ class ParkingFilter(django_filters.rest_framework.FilterSet):
             return queryset.exclude(time_start__lte=now, time_end__gte=now)
 
         return queryset
+
+
+class ParkingException(exceptions.APIException):
+    status_code = 403
+    default_detail = _('Unknown error.')
+    default_code = 'unknown_error'

--- a/parkings/api/operator/parking.py
+++ b/parkings/api/operator/parking.py
@@ -1,11 +1,11 @@
 from django.conf import settings
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
-from rest_framework import exceptions, permissions, serializers, viewsets
+from rest_framework import permissions, serializers, viewsets
 
 from parkings.models import Operator, Parking
 
-from ..common import ParkingFilter
+from ..common import ParkingException, ParkingFilter
 
 
 class OperatorAPIParkingSerializer(serializers.ModelSerializer):
@@ -21,8 +21,9 @@ class OperatorAPIParkingSerializer(serializers.ModelSerializer):
     def validate(self, data):
         if self.instance and (now() - self.instance.created_at) > settings.PARKINGS_TIME_EDITABLE:
             if set(data.keys()) != {'time_end'}:
-                raise exceptions.PermissionDenied(
-                    _('Grace period has passed. Only "time_end" can be updated via PATCH.')
+                raise ParkingException(
+                    _('Grace period has passed. Only "time_end" can be updated via PATCH.'),
+                    code='grace_period_over',
                 )
 
         if self.instance:

--- a/parkings/exception_handler.py
+++ b/parkings/exception_handler.py
@@ -1,0 +1,16 @@
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.views import exception_handler
+
+from parkings.api.common import ParkingException
+
+
+def parkings_exception_handler(exc, context):
+    response = exception_handler(exc, context)
+
+    if response is not None:
+        if isinstance(exc, ParkingException):
+            response.data['code'] = exc.get_codes()
+        elif isinstance(exc, PermissionDenied):
+            response.data['code'] = 'permission_denied'
+
+    return response

--- a/parkings/tests/api/internal/test_parking.py
+++ b/parkings/tests/api/internal/test_parking.py
@@ -49,7 +49,7 @@ def check_parking_data_matches_parking_object(parking_data, parking_obj):
 def test_other_than_staff_cannot_do_anything(unauthenticated_api_client, operator_api_client, parking):
     urls = (list_url, get_detail_url(parking))
     check_method_status_codes(unauthenticated_api_client, urls, ALL_METHODS, 401)
-    check_method_status_codes(operator_api_client, urls, ALL_METHODS, 403)
+    check_method_status_codes(operator_api_client, urls, ALL_METHODS, 403, error_code='permission_denied')
 
 
 def test_disallowed_methods(staff_api_client, parking):

--- a/parkings/tests/api/utils.py
+++ b/parkings/tests/api/utils.py
@@ -41,7 +41,7 @@ def delete(api_client, url, status_code=204):
     assert response.status_code == status_code, '%s %s' % (response.status_code, response.data)
 
 
-def check_method_status_codes(api_client, urls, methods, status_code):
+def check_method_status_codes(api_client, urls, methods, status_code, **kwargs):
     # accept also a single url as a string
     if isinstance(urls, str):
         urls = (urls,)
@@ -52,6 +52,11 @@ def check_method_status_codes(api_client, urls, methods, status_code):
             assert response.status_code == status_code, (
                 '%s %s expected %s, got %s %s' % (method, url, status_code, response.status_code, response.data)
             )
+            error_code = kwargs.get('error_code')
+            if error_code:
+                assert response.data['code'] == error_code, (
+                    '%s %s expected error_code %s, got %s' % (method, url, error_code, response.data['code'])
+                )
 
 
 def check_list_endpoint_base_fields(data):

--- a/parkkihubi/settings.py
+++ b/parkkihubi/settings.py
@@ -158,6 +158,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAuthenticated',),
     'DEFAULT_AUTHENTICATION_CLASSES': ('parkings.authentication.ApiKeyAuthentication',),
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
+    'EXCEPTION_HANDLER': 'parkings.exception_handler.parkings_exception_handler',
     'PAGE_SIZE': 20,
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }


### PR DESCRIPTION
Added error code to 403 API errors to make them machine-readable.

The code is returned in `code` field in 403 response body alongside
the default `detail` field.

current codes:

`unknown_error`: Fallback value, should not be used normally
`permission_denied`: for DRF PermissionDenied()
`grace_period_over`: Parking edit grace period has passed