### PR TITLE
parking areas importer: Fix namespace of avoindata

### DIFF
--- a/parkings/importers/parking_areas.py
+++ b/parkings/importers/parking_areas.py
@@ -29,7 +29,7 @@ class ParkingAreaImporter(object):
         # namespaces for lxml
         self.ns = {
             'wfs': 'http://www.opengis.net/wfs/2.0',
-            'avoindata': 'http://www.hel.fi/avoindata',
+            'avoindata': 'https://www.hel.fi/avoindata',
             'gml': 'http://www.opengis.net/gml/3.2',
         }
         self.overwrite = overwrite

--- a/parkings/importers/parking_areas.py
+++ b/parkings/importers/parking_areas.py
@@ -142,7 +142,7 @@ class ParkingAreaImporter(object):
         logger.info('Getting data from the server.')
         try:
             wfs = WebFeatureService(
-                url='http://kartta.hel.fi/ws/geoserver/avoindata/wfs',
+                url='https://kartta.hel.fi/ws/geoserver/avoindata/wfs',
                 version='2.0.0',
             )
             response = wfs.getfeature(

--- a/parkings/tests/parking_area_importer_data.xml
+++ b/parkings/tests/parking_area_importer_data.xml
@@ -1,4 +1,4 @@
-<wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:avoindata="http://www.hel.fi/avoindata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" numberMatched="1" numberReturned="1">
+<wfs:FeatureCollection xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:avoindata="https://www.hel.fi/avoindata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" numberMatched="1" numberReturned="1">
     <wfs:member>
         <avoindata:liikennemerkkipilotti_pysakointipaikat>
             <avoindata:alue_id>3508</avoindata:alue_id>


### PR DESCRIPTION
It seems that the avoindata namespace has changed from http to https in
the received XML content.  Amend the importer so that it can import the
data again.