### PR TITLE
operator API: Default to UTC for start/end time

### DIFF
--- a/parkings/api/operator/parking.py
+++ b/parkings/api/operator/parking.py
@@ -1,3 +1,4 @@
+import pytz
 from django.conf import settings
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
@@ -26,6 +27,11 @@ class OperatorAPIParkingSerializer(serializers.ModelSerializer):
             'location': {'default': None},
             'time_end': {'default': None},
         }
+
+    def __init__(self, *args, **kwargs):
+        super(OperatorAPIParkingSerializer, self).__init__(*args, **kwargs)
+        self.fields['time_start'].timezone = pytz.utc
+        self.fields['time_end'].timezone = pytz.utc
 
     def validate(self, data):
         if self.instance and (now() - self.instance.created_at) > settings.PARKKIHUBI_TIME_PARKINGS_EDITABLE:

--- a/parkings/tests/api/internal/test_parking.py
+++ b/parkings/tests/api/internal/test_parking.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 
 import pytest
+import pytz
 from django.core.urlresolvers import reverse
 from django.utils.timezone import utc
 
@@ -155,7 +156,10 @@ def test_time_filters(operator, staff_api_client, parking_factory, filtering, ex
     ('time_end__gte=2020-01-01T12:00:00Z', True),
 ])
 def test_end_time_filters_no_end_time(operator, staff_api_client, parking_factory, filtering, expected_visibility):
-    parking = parking_factory(time_start=datetime(2018, 1, 1), time_end=None, operator=operator)
+    parking = parking_factory(
+        time_start=datetime(2018, 1, 1, tzinfo=pytz.utc),
+        time_end=None,
+        operator=operator)
 
     response = get(staff_api_client, list_url + '?' + filtering)
     check_response_objects(response, parking if expected_visibility else [])


### PR DESCRIPTION
Use UTC timezone for start/end time fields when no timezone is specified
in data of the POST request.