### PR TITLE
Parking: Fix converting non-digit to int on save

### DIFF
--- a/parkings/models/parking.py
+++ b/parkings/models/parking.py
@@ -85,7 +85,7 @@ class Parking(TimestampedModelMixin, UUIDPrimaryKeyMixin):
     def save(self, *args, **kwargs):
         if not self.terminal and self.terminal_number:
             self.terminal = ParkingTerminal.objects.filter(
-                number=self.terminal_number).first()
+                number=_try_cast_int(self.terminal_number)).first()
 
         if self.terminal and not self.location:
             self.location = self.terminal.location
@@ -93,3 +93,10 @@ class Parking(TimestampedModelMixin, UUIDPrimaryKeyMixin):
         self.parking_area = self.get_closest_area()
 
         super(Parking, self).save(*args, **kwargs)
+
+
+def _try_cast_int(value):
+    try:
+        return int(value)
+    except ValueError:
+        return None

--- a/parkings/tests/test_models.py
+++ b/parkings/tests/test_models.py
@@ -77,6 +77,17 @@ def test_location_set_from_terminal(admin_user):
 
 
 @pytest.mark.django_db
+def test_parking_save_with_nondigit_terminal_number(admin_user):
+    operator = Operator.objects.get_or_create(user=admin_user)[0]
+    parking = create_parking(operator_id=operator.pk, terminal_number='123a')
+    parking.location = None
+    parking.save()
+    assert parking.terminal is None
+    assert parking.location is None
+    assert parking.terminal_number == '123a'
+
+
+@pytest.mark.django_db
 def test_location_not_overridden_from_terminal(admin_user):
     operator = Operator.objects.get_or_create(user=admin_user)[0]
     terminal = ParkingTerminal.objects.get_or_create(


### PR DESCRIPTION
When a Parking with a terminal_number number is saved, the save function
tries find a terminal by the terminal number.  This lookup does an
implicit conversion to integer, because the Terminal.number field is an
integer field.  That caused couple exceptions.

Fix this by making sure that only an integer or None is passed to the
filter call.