### PR TITLE
Revert "Hide registration numbers in admin"

### DIFF
--- a/parkings/admin.py
+++ b/parkings/admin.py
@@ -10,10 +10,9 @@ class OperatorAdmin(admin.ModelAdmin):
 
 @admin.register(Parking)
 class ParkingAdmin(OSMGeoAdmin):
-    exclude = ['registration_number']
     list_display = [
         'id', 'operator', 'zone', 'parking_area', 'terminal_number',
-        'time_start', 'time_end',
+        'time_start', 'time_end', 'registration_number',
         'created_at', 'modified_at']
     list_filter = ['operator', 'zone']
     ordering = ('-created_at',)

--- a/parkings/models/parking.py
+++ b/parkings/models/parking.py
@@ -51,14 +51,14 @@ class Parking(TimestampedModelMixin, UUIDPrimaryKeyMixin):
         start = localtime(self.time_start).replace(tzinfo=None)
 
         if self.time_end is None:
-            return "%s -> (%s)" % (start, 'ABC-123')
+            return "%s -> (%s)" % (start, self.registration_number)
 
         if self.time_start.date() == self.time_end.date():
             end = localtime(self.time_end).time().replace(tzinfo=None)
         else:
             end = localtime(self.time_end).replace(tzinfo=None)
 
-        return "%s -> %s (%s)" % (start, end, 'ABC-123')
+        return "%s -> %s (%s)" % (start, end, self.registration_number)
 
     def get_state(self):
         current_timestamp = now()


### PR DESCRIPTION
Hiding of the registration numbers was only a temporary need.  Make them
visible again.

This reverts commit e9d90b911f6645d44d405e9951c84f400a5f8151.