### PR TITLE
requirements: Add python-memcached

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -23,5 +23,6 @@ lxml
 owslib
 
 # Misc
-pytz
 django-cors-headers
+python-memcached
+pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,9 @@ psycopg2==2.7.3.2
 pyjwt==1.5.3              # via djangorestframework-jwt
 pyproj==1.9.5.1           # via owslib
 python-dateutil==2.6.1    # via owslib
+python-memcached==1.59
 pytz==2017.3
 raven==6.5.0
 requests==2.18.4          # via owslib
-six==1.11.0               # via django-environ, djangorestframework-gis, python-dateutil
+six==1.11.0               # via django-environ, djangorestframework-gis, python-dateutil, python-memcached
 urllib3==1.22             # via requests


### PR DESCRIPTION
Memcached is used in production, so add it to requirements.

This should have been part of commit a0431f1, which added drf-jwt-2fa,
since it uses the Django cache framework.

Refs HP-31