### PR TITLE
Changes to post-update hook for pubapi server (HP-50)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - env: TOXENV=requirements
       python: "3.4"
       addons: null
-      before_script: null
+      before_script: pip install pip==18.0  # See also post-update script
     - env: TOXENV=style
       python: "3.4"
       addons: null

--- a/post-update
+++ b/post-update
@@ -27,8 +27,14 @@ fi
 # Update the backend
 pip install prequ==1.3.1
 prequ sync requirements.txt
+
 ./manage.py collectstatic --noinput
-./manage.py migrate --noinput
+
+if [ "$DISABLE_MIGRATIONS_ON_DEPLOY" = "1" ]; then
+    echo "Skipping migrations, since DISABLE_MIGRATIONS_ON_DEPLOY is set."
+else
+    ./manage.py migrate --noinput
+fi
 
 # Send notification about succesful update
 if [ -x ../bin/update-notify ]; then

--- a/post-update
+++ b/post-update
@@ -25,7 +25,10 @@ elif [ "$force_update" = "true" ] || \
 fi
 
 # Update the backend
-pip install prequ==1.3.1
+
+# Note: Keep Pip and Prequ version in sync with tox.ini and .travis.yml
+pip install pip==18.0
+pip install prequ==1.4.2
 prequ sync requirements.txt
 
 ./manage.py collectstatic --noinput

--- a/post-update
+++ b/post-update
@@ -7,7 +7,9 @@ if [ -r ../etc/env ]; then
 fi
 
 # Update the dashboard
-if [ "$force_update" = "true" ] || \
+if [ "$DISABLE_DASHBOARD_DEPLOY" = "1" ]; then
+    echo "Not deploying Dashboard, since DISABLE_DASHBOARD_DEPLOY is set."
+elif [ "$force_update" = "true" ] || \
        git diff --name-only "$prev_head..HEAD" | grep -q "^dashboard/"; then
     if [ "$TIER" != "prod" ]; then
         export REACT_APP_API_URL="https://testapi.parkkiopas.fi/"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,3 +30,6 @@ typing==3.6.4             # via django-extensions, ipython
 virtualenv==15.1.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit
 werkzeug==0.14.1
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools                # via ipython

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -18,3 +18,6 @@ python-dateutil==2.6.1    # via faker, freezegun
 pyyaml==3.12
 six==1.11.0               # via faker, freezegun, pytest, python-dateutil
 text-unidecode==1.1       # via faker
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools                # via pytest

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,8 @@ commands = py.test -ra -vvv --strict --cov {posargs}
 
 [testenv:requirements]
 basepython = python3.4
-deps = prequ==1.3.1
+# Note: Keep Prequ version in sync with post-update script
+deps = prequ==1.4.2
 commands = prequ {posargs:check -v}
 
 [testenv:style]


### PR DESCRIPTION
Allow skipping migrations on deploy and skipping the deployment of
Dashboard with environment variables.