### PR TITLE
Travis: Update PostgreSQL to 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ matrix:
     - python: "3.5"
     - python: "3.6"
     - env: TOXENV=requirements
-      python: "3.4"
+      python: "3.5"
       addons: null
       before_script: pip install pip==18.0  # See also post-update script
     - env: TOXENV=style
-      python: "3.4"
+      python: "3.5"
       addons: null
       before_script: null
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
-# Postgis doesn't work on older 'precise' platform
-# and the default depends on repo age (parkkihubi is too old)
-sudo: false
-dist: trusty
+sudo: yes
+dist: xenial
 
 language: python
 
@@ -22,13 +20,13 @@ matrix:
       before_script: null
 
 
-# As of 2017-08 the new travis trusty images have broken postgis,
-# so we have to specify the exact postgres version to install right addons
 addons:
-  postgresql: 9.6
+  postgresql: "10"
   apt:
     packages:
-    - postgresql-9.6-postgis-2.3
+    - postgresql-10
+    - postgresql-client-10
+    - postgresql-10-postgis-2.4
 
 install: pip install tox-travis codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache: pip
 
 matrix:
   include:
-    - python: "3.4"
     - python: "3.5"
     - python: "3.6"
     - env: TOXENV=requirements

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ six==1.11.0               # via django-extensions, prompt-toolkit, pydocstyle, t
 snowballstemmer==1.2.1    # via pydocstyle
 tox==2.9.1
 traitlets==4.3.2          # via ipython
-typing==3.6.4             # via django-extensions, ipython
+typing==3.6.4             # via django-extensions
 virtualenv==15.1.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit
 werkzeug==0.14.1

--- a/tox.ini
+++ b/tox.ini
@@ -13,12 +13,12 @@ setenv =
 commands = py.test -ra -vvv --strict --cov {posargs}
 
 [testenv:requirements]
-basepython = python3.4
+basepython = python3.5
 # Note: Keep Prequ version in sync with post-update script
 deps = prequ==1.4.2
 commands = prequ {posargs:check -v}
 
 [testenv:style]
-basepython = python3.4
+basepython = python3.5
 deps = -rrequirements-style.txt
 commands = flake8 {posargs:--enable=T}


### PR DESCRIPTION
Use PostgreSQL 10 to test, because that is in use on the servers.

Also make Python 3.5 the default Python version on tests, because that
is in use in the servers.