### PR TITLE
Update Prequ to 1.4.4 and Pip to 19.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - env: TOXENV=requirements
       python: "3.5"
       addons: null
-      before_script: pip install pip==18.0  # See also post-update script
+      before_script: null
     - env: TOXENV=style
       python: "3.5"
       addons: null

--- a/post-update
+++ b/post-update
@@ -26,9 +26,9 @@ fi
 
 # Update the backend
 
-# Note: Keep Pip and Prequ version in sync with tox.ini and .travis.yml
-pip install pip==18.0
-pip install prequ==1.4.2
+# Note: Keep Pip and Prequ version in sync with tox.ini
+pip install pip==19.0.3
+pip install prequ==1.4.4
 prequ sync requirements.txt
 
 ./manage.py collectstatic --noinput

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,10 @@ commands = py.test -ra -vvv --strict --cov {posargs}
 
 [testenv:requirements]
 basepython = python3.5
-# Note: Keep Prequ version in sync with post-update script
-deps = prequ==1.4.2
+# Note: Keep Pip and Prequ version in sync with post-update script
+deps =
+    pip==19.0.3
+    prequ==1.4.4
 commands = prequ {posargs:check -v}
 
 [testenv:style]


### PR DESCRIPTION
Update Prequ to 1.4.4 in the requirements check configured for Tox and
in the post-update hook script, which is ran by the deployment script.
In addition update Pip to the latest version, 19.0.3, in these same
files.

Remove "pip install pip==18.0" before_script command from the Travis
configuration, since it does not have any effect, because Tox will
create another virtualenv with a different Pip version for the
requirements check anyway.