### PR TITLE
requirements: Update to newest versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,14 +8,15 @@ autoflake==1.3
 autopep8==1.4.4
 backcall==0.1.0           # via ipython
 decorator==4.4.0          # via ipython, traitlets
-django-extensions==2.1.7
+django-extensions==2.1.9
 filelock==3.0.12          # via tox
-importlib-metadata==0.17  # via pluggy
-ipython==7.5.0
+importlib-metadata==0.18  # via pluggy, tox
+ipython==7.6.0
 ipython-genutils==0.2.0   # via traitlets
-isort==4.3.20
-jedi==0.13.3              # via ipython
-parso==0.4.0              # via jedi
+isort==4.3.21
+jedi==0.14.0              # via ipython
+packaging==19.0           # via tox
+parso==0.5.0              # via jedi
 pexpect==4.7.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pluggy==0.12.0            # via tox
@@ -26,15 +27,16 @@ pycodestyle==2.5.0        # via autopep8
 pydocstyle==3.0.0
 pyflakes==2.1.1           # via autoflake
 pygments==2.4.2           # via ipython
-six==1.12.0               # via django-extensions, prompt-toolkit, pydocstyle, tox, traitlets
-snowballstemmer==1.2.1    # via pydocstyle
+pyparsing==2.4.0          # via packaging
+six==1.12.0               # via django-extensions, packaging, prompt-toolkit, pydocstyle, tox, traitlets
+snowballstemmer==1.9.0    # via pydocstyle
 toml==0.10.0              # via tox
-tox==3.12.1
+tox==3.13.1
 traitlets==4.3.2          # via ipython
-virtualenv==16.6.0        # via tox
+virtualenv==16.6.1        # via tox
 wcwidth==0.1.7            # via prompt-toolkit
 werkzeug==0.15.4
 zipp==0.5.1               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools                # via ipython, tox
+# setuptools                # via ipython

--- a/requirements-style.txt
+++ b/requirements-style.txt
@@ -9,10 +9,10 @@ flake8==3.7.7
 flake8-isort==2.7.0
 flake8-polyfill==1.0.2    # via pep8-naming
 flake8-print==3.1.0
-isort==4.3.20             # via flake8-isort
+isort==4.3.21             # via flake8-isort
 mccabe==0.6.1             # via flake8
 pep8-naming==0.8.2
 pycodestyle==2.5.0        # via flake8, flake8-print
 pyflakes==2.1.1           # via flake8
 six==1.12.0               # via flake8-print
-testfixtures==6.8.2       # via flake8-isort
+testfixtures==6.10.0      # via flake8-isort

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,32 +6,31 @@
 
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
-certifi==2019.3.9         # via requests
+certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
 coverage==4.5.3           # via pytest-cov
 factory-boy==2.12.0
 faker==1.0.7              # via factory-boy
 freezegun==0.3.12
 idna==2.8                 # via requests
-importlib-metadata==0.17  # via pluggy
+importlib-metadata==0.18  # via pluggy, pytest
 inflection==0.3.1         # via pytest-factoryboy
-more-itertools==7.0.0     # via pytest
-pathlib2==2.3.3           # via pytest
+more-itertools==7.1.0     # via pytest
+packaging==19.0           # via pytest
+pathlib2==2.3.4           # via pytest
 pluggy==0.12.0            # via pytest
 py==1.8.0                 # via pytest
-pytest==4.5.0
+pyparsing==2.4.0          # via packaging
+pytest==4.6.4
 pytest-cov==2.7.1
-pytest-django==3.4.8
+pytest-django==3.5.1
 pytest-factoryboy==2.0.2
 python-dateutil==2.8.0    # via faker, freezegun
-pyyaml==5.1
+pyyaml==5.1.1
 requests==2.22.0          # via requests-mock
 requests-mock==1.6.0
-six==1.12.0               # via faker, freezegun, pathlib2, pytest, python-dateutil, requests-mock
+six==1.12.0               # via faker, freezegun, packaging, pathlib2, pytest, python-dateutil, requests-mock
 text-unidecode==1.2       # via faker
 urllib3==1.25.3           # via requests
 wcwidth==0.1.7            # via pytest
 zipp==0.5.1               # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools                # via pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,10 @@
 #
 --no-binary psycopg2
 
-certifi==2019.3.9         # via requests
+aenum==2.1.2              # via pyproj
+certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
-django==1.11.20
+django==1.11.21
 django-cors-headers==3.0.2
 django-environ==0.4.5
 django-filter==2.1.0
@@ -15,11 +16,11 @@ djangorestframework-gis==0.14
 djangorestframework-jwt==1.11.0  # via drf-jwt-2fa
 drf-jwt-2fa==0.3.0
 idna==2.8                 # via requests
-lxml==4.3.3
-owslib==0.17.1
-psycopg2==2.8.2
+lxml==4.3.4
+owslib==0.18.0
+psycopg2==2.8.3
 pyjwt==1.7.1              # via djangorestframework-jwt
-pyproj==2.1.3             # via owslib
+pyproj==2.2.1             # via owslib
 python-dateutil==2.8.0    # via owslib
 python-memcached==1.59
 pytz==2019.1


### PR DESCRIPTION
Update all Python requirements to newest available versions except
pytest, which is not yet updated to 5.0.0, because the newest release of
pytest-factoryboy (2.0.2) is not yet compatible with pytest 5.0.0. (See
https://github.com/pytest-dev/pytest-factoryboy/issues/77).