### PR TITLE
Fix Permit cleaning not being called on bulk creation

### DIFF
--- a/parkings/migrations/0019_permits.py
+++ b/parkings/migrations/0019_permits.py
@@ -24,13 +24,13 @@ class Migration(migrations.Migration):
                 ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='time created')),
                 ('modified_at', models.DateTimeField(auto_now=True, verbose_name='time modified')),
                 ('external_id', models.CharField(blank=True, max_length=50, null=True)),
-                ('subjects', CleaningJsonField(validators=[
+                ('subjects', CleaningJsonField(blank=True, validators=[
                     DictListValidator({
                         'start_time': TimestampField(),
                         'end_time': TimestampField(),
                         'registration_number': TextField(max_length=20),
                     })])),
-                ('areas', CleaningJsonField(validators=[
+                ('areas', CleaningJsonField(blank=True, validators=[
                     DictListValidator({
                         'start_time': TimestampField(),
                         'end_time': TimestampField(),

--- a/parkings/models/permit.py
+++ b/parkings/models/permit.py
@@ -81,12 +81,12 @@ class PermitQuerySet(models.QuerySet):
 class Permit(TimestampedModelMixin, models.Model):
     series = models.ForeignKey(PermitSeries, on_delete=models.PROTECT)
     external_id = models.CharField(max_length=50, null=True, blank=True)
-    subjects = CleaningJsonField(validators=[DictListValidator({
+    subjects = CleaningJsonField(blank=True, validators=[DictListValidator({
         'start_time': TimestampField(),
         'end_time': TimestampField(),
         'registration_number': TextField(max_length=20),
     })])
-    areas = CleaningJsonField(validators=[DictListValidator({
+    areas = CleaningJsonField(blank=True, validators=[DictListValidator({
         'start_time': TimestampField(),
         'end_time': TimestampField(),
         'area': TextField(max_length=10),

--- a/parkings/models/permit.py
+++ b/parkings/models/permit.py
@@ -72,6 +72,7 @@ class PermitQuerySet(models.QuerySet):
             cache_items = []
             for permit in created_permits:
                 assert isinstance(permit, Permit)
+                permit.full_clean()
                 cache_items.extend(permit._make_cache_items())
             PermitCacheItem.objects.using(self.db).bulk_create(cache_items)
             return created_permits

--- a/parkings/tests/api/enforcement/test_permit.py
+++ b/parkings/tests/api/enforcement/test_permit.py
@@ -38,6 +38,20 @@ def test_permit_is_created_with_valid_post_data(staff_api_client, permit_series)
     assert response.status_code == HTTP_201_CREATED
 
 
+@pytest.mark.django_db
+def test_permit_is_created_with_empty_lists(staff_api_client, permit_series):
+    permit_data = {
+        'series': permit_series.id,
+        'external_id': "E-123",
+        'subjects': [],
+        'areas': [],
+    }
+
+    response = staff_api_client.post(list_url, data=permit_data)
+
+    assert response.status_code == HTTP_201_CREATED
+
+
 TS1 = '2019-01-01T12:00:00Z'
 TS2 = '2019-06-30T12:00:00Z'
 INVALID_DATA_TEST_CASES = {

--- a/parkings/tests/api/enforcement/test_permit.py
+++ b/parkings/tests/api/enforcement/test_permit.py
@@ -75,10 +75,11 @@ INVALID_DATA_TEST_CASES = {
           'registration_number': 'X-14'}],
         'Invalid "end_time" value \'2019-12-31T00:00:00\': Missing timezone'),
 }
+@pytest.mark.parametrize('kind', ['single', 'bulk'])
 @pytest.mark.parametrize('test_case', INVALID_DATA_TEST_CASES.keys())
 @pytest.mark.django_db
 def test_permit_is_not_created_with_invalid_post_data(
-        staff_api_client, permit_series, test_case):
+        staff_api_client, kind, permit_series, test_case):
     (subjects, error) = INVALID_DATA_TEST_CASES[test_case]
     invalid_permit_data = {
         'series': permit_series.id,
@@ -87,12 +88,18 @@ def test_permit_is_not_created_with_invalid_post_data(
         'areas': generate_areas()
     }
 
-    response = staff_api_client.post(list_url, data=invalid_permit_data)
+    if kind == 'single':
+        response = staff_api_client.post(list_url, data=invalid_permit_data)
+        data = response.data
+    else:
+        response = staff_api_client.post(list_url, data=[invalid_permit_data])
+        data = response.data[0]
 
     assert response.status_code == HTTP_400_BAD_REQUEST
-    assert response.data['subjects'] == [error]
+    assert data['subjects'] == [error]
 
 
+@pytest.mark.parametrize('kind', ['single', 'bulk'])
 @pytest.mark.parametrize('input_timestamp,normalized_timestamp', [
     ('1995-01-01 12:00Z', '1995-01-01T12:00:00+00:00'),
     ('2030-06-30T12:00+03:00', '2030-06-30T09:00:00+00:00'),
@@ -102,7 +109,9 @@ def test_permit_is_not_created_with_invalid_post_data(
 ])
 @pytest.mark.django_db
 def test_permit_creation_normalizes_timestamps(
-        staff_api_client, permit_series, input_timestamp, normalized_timestamp):
+        staff_api_client, permit_series,
+        kind,
+        input_timestamp, normalized_timestamp):
     permit_data = {
         'series': permit_series.id,
         'external_id': 'E123',
@@ -118,11 +127,16 @@ def test_permit_creation_normalizes_timestamps(
         }],
     }
 
-    response = staff_api_client.post(list_url, data=permit_data)
+    if kind == 'single':
+        response = staff_api_client.post(list_url, data=permit_data)
+        data = response.data
+    else:
+        response = staff_api_client.post(list_url, data=[permit_data])
+        data = response.data[0]
 
     assert response.status_code == HTTP_201_CREATED
-    assert response.data['subjects'][0]['end_time'] == normalized_timestamp
-    assert response.data['areas'][0]['end_time'] == normalized_timestamp
+    assert data['subjects'][0]['end_time'] == normalized_timestamp
+    assert data['areas'][0]['end_time'] == normalized_timestamp
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
It seems that full_clean was not called when bulk creating permits.  Fix
this and add test cases which check it.

Also allow empty list as value to "subjects" or "areas" fields, since
that's how it was specified.