### PR TITLE
Permits: Interpret timestamps without timezone as UTC

### DIFF
--- a/parkings/tests/api/enforcement/test_permit.py
+++ b/parkings/tests/api/enforcement/test_permit.py
@@ -84,10 +84,6 @@ INVALID_DATA_TEST_CASES = {
     'invalid-timestamp': (
         [{'start_time': TS1, 'end_time': '', 'registration_number': 'X-14'}],
         'Invalid "end_time" value \'\': Not a timestamp string'),
-    'no-timezone': (
-        [{'start_time': TS1, 'end_time': '2019-12-31T00:00:00',
-          'registration_number': 'X-14'}],
-        'Invalid "end_time" value \'2019-12-31T00:00:00\': Missing timezone'),
 }
 @pytest.mark.parametrize('kind', ['single', 'bulk'])
 @pytest.mark.parametrize('test_case', INVALID_DATA_TEST_CASES.keys())
@@ -120,6 +116,7 @@ def test_permit_is_not_created_with_invalid_post_data(
     ('1995-01-01 12:00:00 UTC', '1995-01-01T12:00:00+00:00'),
     ('2019-05-30T12:00:00.123Z', '2019-05-30T12:00:00.123000+00:00'),
     ('2019-05-30T12:00:00.999999 +00:00', '2019-05-30T12:00:00.999999+00:00'),
+    ('2019-12-31T00:00:00', '2019-12-31T00:00:00+00:00'),  # No timezone as UTC
 ])
 @pytest.mark.django_db
 def test_permit_creation_normalizes_timestamps(

--- a/parkings/validators.py
+++ b/parkings/validators.py
@@ -49,7 +49,8 @@ class TimestampField(TextField):
             raise ValidationError(_('Not a timestamp string'))
 
         if not dt.tzinfo:
-            raise ValidationError(_('Missing timezone'))
+            # Interpret timestamps without a timezone as UTC
+            dt = dt.replace(tzinfo=timezone.utc)
 
         return dt.astimezone(timezone.utc).isoformat()
 


### PR DESCRIPTION
Interpret the non-timezoned timestamps entered into start_time and
end_time fields of the Permit objects as UTC, since we know that
currently the only client of this API is still pushing non-timezoned
timestamps.  This commit can be reverted when the client side code has
been updated to push timezoned timestamps.