### PR TITLE
check_parking: Improve parameter checks

### DIFF
--- a/parkings/api/enforcement/check_parking.py
+++ b/parkings/api/enforcement/check_parking.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.conf import settings
+from django.contrib.gis.gdal.error import GDALException
 from django.contrib.gis.geos import Point
 from django.utils import timezone
 from rest_framework import generics, permissions, serializers
@@ -96,11 +97,19 @@ def get_location(params):
     longitude = params["location"]["longitude"]
     latitude = params["location"]["latitude"]
     wgs84_location = Point(longitude, latitude, srid=WGS84_SRID)
-    gk25_location = wgs84_location.transform(GK25FIN_SRID, clone=True)
+    try:
+        gk25_location = wgs84_location.transform(GK25FIN_SRID, clone=True)
+    except GDALException:
+        # GK25-FIN doesn't cover the whole world, and therefore
+        # locations outside of its projection plane will raise a
+        # GDALException.  In that case return None as the gk25_location.
+        return (wgs84_location, None)
     return (wgs84_location, gk25_location)
 
 
 def get_payment_zone(location):
+    if location is None:
+        return None
     zone_numbers = (
         PaymentZone.objects
         .filter(geom__contains=location)
@@ -110,6 +119,8 @@ def get_payment_zone(location):
 
 
 def get_permit_area(location):
+    if location is None:
+        return None
     area = PermitArea.objects.filter(geom__contains=location).first()
     return area.identifier if area else None
 

--- a/parkings/api/enforcement/check_parking.py
+++ b/parkings/api/enforcement/check_parking.py
@@ -24,8 +24,8 @@ class AwareDateTimeField(serializers.DateTimeField):
 
 
 class LocationSerializer(serializers.Serializer):
-    latitude = serializers.FloatField()
-    longitude = serializers.FloatField()
+    latitude = serializers.FloatField(min_value=-90, max_value=90)
+    longitude = serializers.FloatField(min_value=-180, max_value=180)
 
 
 class CheckParkingSerializer(serializers.Serializer):

--- a/parkings/tests/api/enforcement/test_check_parking.py
+++ b/parkings/tests/api/enforcement/test_check_parking.py
@@ -234,6 +234,19 @@ def test_infinite_latitude_returns_bad_request(staff_api_client):
         " are not JSON compliant: 'Infinity'")
 
 
+@pytest.mark.parametrize("longitude", [-180, 0.0, 180.0])
+@pytest.mark.parametrize("latitude", [-90.0, 0.0, 90.0])
+def test_extreme_locations_are_ok(
+        staff_api_client, latitude, longitude):
+    location = {"latitude": latitude, "longitude": longitude}
+    input_data = dict(PARKING_DATA, location=location)
+    response = staff_api_client.post(list_url, data=input_data)
+
+    assert response.status_code == HTTP_200_OK
+    assert ParkingCheck.objects.first().location.coords == (
+        longitude, latitude)
+
+
 def test_requested_time_must_have_timezone(staff_api_client):
     naive_dt = datetime.datetime(2011, 1, 31, 12, 34, 56, 123456)
     input_data = dict(PARKING_DATA, time=naive_dt)

--- a/parkings/tests/api/enforcement/test_check_parking.py
+++ b/parkings/tests/api/enforcement/test_check_parking.py
@@ -271,6 +271,16 @@ def test_invalid_regnum_returns_bad_request(staff_api_client, case):
     assert response.data["registration_number"] == [error_text]
 
 
+def test_invalid_timestamp_string_returns_bad_request(staff_api_client):
+    input_data = dict(PARKING_DATA, time="invalid-timestamp")
+    response = staff_api_client.post(list_url, data=input_data)
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.data["time"] == [
+        ("Date has wrong format. Use one of these formats instead:"
+         " YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z].")]
+
+
 def test_requested_time_must_have_timezone(staff_api_client):
     naive_dt = datetime.datetime(2011, 1, 31, 12, 34, 56, 123456)
     input_data = dict(PARKING_DATA, time=naive_dt)

--- a/parkings/tests/api/enforcement/test_check_parking.py
+++ b/parkings/tests/api/enforcement/test_check_parking.py
@@ -247,6 +247,30 @@ def test_extreme_locations_are_ok(
         longitude, latitude)
 
 
+INVALID_REGNUM_TEST_CASES = {
+    "too-long": (
+        "123456789012345678901",
+        "Ensure this field has no more than 20 characters."),
+    "blank": (
+        "",
+        "This field may not be blank."),
+    "list": (
+        ["ABC-123"],
+        "Not a valid string."),
+    "dict": (
+        {"ABC-123": "ABC-123"},
+        "Not a valid string."),
+}
+@pytest.mark.parametrize("case", INVALID_REGNUM_TEST_CASES.keys())
+def test_invalid_regnum_returns_bad_request(staff_api_client, case):
+    (regnum, error_text) = INVALID_REGNUM_TEST_CASES[case]
+    input_data = dict(PARKING_DATA, registration_number=regnum)
+    response = staff_api_client.post(list_url, data=input_data)
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.data["registration_number"] == [error_text]
+
+
 def test_requested_time_must_have_timezone(staff_api_client):
     naive_dt = datetime.datetime(2011, 1, 31, 12, 34, 56, 123456)
     input_data = dict(PARKING_DATA, time=naive_dt)


### PR DESCRIPTION
Implement better checks for the parameters provided to the check_parking
endpoint.  This should make it harder to crash the endpoint, e.g. by
providing a non-existent location or a location outside of GK25FIN as
input.

Also add more test cases to check other parameters besides the location.