### PR TITLE
Improve model admins

### DIFF
--- a/parkings/admin_utils.py
+++ b/parkings/admin_utils.py
@@ -13,3 +13,13 @@ class ReadOnlyAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+
+class WithAreaField:
+    area_scale = 1000000
+
+    def area(self, instance):
+        assert self.area_scale in [1000000, 1]
+        unit = 'km\u00b2' if self.area_scale == 1000000 else 'm\u00b2'
+        return '{area:.1f} {unit}'.format(
+            area=instance.geom.area / self.area_scale, unit=unit)

--- a/parkings/migrations/0019_permits.py
+++ b/parkings/migrations/0019_permits.py
@@ -62,6 +62,8 @@ class Migration(migrations.Migration):
             ],
             options={
                 'ordering': ('created_at', 'id'),
+                'verbose_name': 'permit series',
+                'verbose_name_plural': 'permit series',
             },
         ),
         migrations.AddField(

--- a/parkings/models/permit.py
+++ b/parkings/models/permit.py
@@ -46,6 +46,8 @@ class PermitSeries(TimestampedModelMixin, models.Model):
 
     class Meta:
         ordering = ('created_at', 'id')
+        verbose_name = _("permit series")
+        verbose_name_plural = _("permit series")
 
     def __str__(self):
         return str(self.id)
@@ -103,7 +105,11 @@ class Permit(TimestampedModelMixin, models.Model):
         ordering = ('series', 'id')
 
     def __str__(self):
-        return ('Permit {}'.format(self.id))
+        return 'Permit {id} ({series}{active} / {external_id})'.format(
+            id=self.id,
+            series=self.series,
+            active='*' if self.series.active else '',
+            external_id=self.external_id)
 
     def save(self, using=None, *args, **kwargs):
         self.full_clean()


### PR DESCRIPTION
Make the following improvements to the Django Admin parts in the
parkings app:

 * Add PermitSeriesAdmin for browsing permit series

 * Tune ordering of the items

 * Add new fields to the list displays

 * Add date hierarchy to ParkingAdmin and PermitAdmin

 * Add area fields to the ParkingAreaAdmin, PaymentZoneAdmin,
   PermitAreaAdmin and RegionAdmin to display their area size.

 * Improve string presentation of Permit objects.

 * Add verbose name for PermitSeries model.