### PR TITLE
Travis: Fix codecov to work again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ addons:
     - postgresql-client-10
     - postgresql-10-postgis-2.4
 
-install: pip install tox-travis codecov
+install: pip install tox-travis
 
 before_script: psql -U postgres -c "create extension postgis"
 
 script: tox
 
-after_success: codecov
+after_success: pip install codecov coverage==4.5.4 && codecov


### PR DESCRIPTION
Currently codecov is not working, because there is an issue that it
doesn't work with the coverage 5.0 Python package.  Fix this issue by
making sure that coverage 4.x is used instead.

See the coverage error in the Travis build logs for latest master
builds (e.g. [1]) and the codecov issue [2]

[1] https://travis-ci.org/City-of-Helsinki/parkkihubi/jobs/639843555#L1003

[2] https://github.com/codecov/codecov-python/issues/224