### PR TITLE
Remove pasi user factory

### DIFF
--- a/parkings/factories/__init__.py
+++ b/parkings/factories/__init__.py
@@ -4,8 +4,7 @@ from .parking import (  # noqa
 from .parking_area import ParkingAreaFactory  # noqa
 from .permit import ActivePermitFactory, PermitFactory, PermitSeriesFactory
 from .region import RegionFactory
-from .user import (  # noqa
-    AdminUserFactory, PasiUserFactory, StaffUserFactory, UserFactory)
+from .user import AdminUserFactory, StaffUserFactory, UserFactory  # noqa
 
 __all__ = [
     'ActivePermitFactory',
@@ -15,7 +14,6 @@ __all__ = [
     'OperatorFactory',
     'ParkingAreaFactory',
     'ParkingFactory',
-    'PasiUserFactory',
     'PermitFactory',
     'PermitSeriesFactory',
     'RegionFactory',

--- a/parkings/factories/permit.py
+++ b/parkings/factories/permit.py
@@ -6,7 +6,7 @@ import pytz
 from parkings.models import Permit, PermitSeries
 
 from .faker import fake
-from .user import PasiUserFactory
+from .user import UserFactory
 
 CAPITAL_LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZÅÄÖ'
 
@@ -53,7 +53,7 @@ def generate_external_ids(id_length=11):
 class PermitSeriesFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = PermitSeries
-    owner = factory.SubFactory(PasiUserFactory)
+    owner = factory.SubFactory(UserFactory)
 
 
 class PermitFactory(factory.django.DjangoModelFactory):

--- a/parkings/factories/user.py
+++ b/parkings/factories/user.py
@@ -17,14 +17,6 @@ class StaffUserFactory(factory.django.DjangoModelFactory):
     is_staff = True
 
 
-class PasiUserFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = User
-        django_get_or_create = ('username',)
-
-    username = 'PASI'
-
-
 class AdminUserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = User

--- a/parkings/migrations/0030_domain_data.py
+++ b/parkings/migrations/0030_domain_data.py
@@ -72,7 +72,7 @@ def _get_or_create_permit_owner(apps):
     permit_owner, created = user_model.objects.get_or_create(
         username='PASI',
         defaults={
-            'is_superuser': True,
+            'is_staff': True
         }
     )
     return permit_owner

--- a/parkings/tests/api/enforcement/test_activate_permit_series.py
+++ b/parkings/tests/api/enforcement/test_activate_permit_series.py
@@ -11,10 +11,9 @@ def get_url(obj):
     return reverse('enforcement:v1:permitseries-detail', kwargs={'pk': obj.pk})
 
 
-def test_series_get_activated(staff_api_client, pasi_user_factory):
-    pasi_user = pasi_user_factory()
-    new_permit_series = PermitSeries.objects.create(active=False, owner=pasi_user)
-    old_permit_series = PermitSeries.objects.create(active=True, owner=pasi_user)
+def test_series_get_activated(staff_api_client, staff_user):
+    new_permit_series = PermitSeries.objects.create(active=False, owner=staff_user)
+    old_permit_series = PermitSeries.objects.create(active=True, owner=staff_user)
 
     response = staff_api_client.post(get_url(new_permit_series) + 'activate/')
 
@@ -24,10 +23,9 @@ def test_series_get_activated(staff_api_client, pasi_user_factory):
     assert not PermitSeries.objects.get(id=old_permit_series.id).active
 
 
-def test_old_series_are_pruned(staff_api_client, pasi_user_factory):
-    pasi_user = pasi_user_factory()
-    new_permit_series = PermitSeries.objects.create(active=False, owner=pasi_user)
-    old_permit_series = PermitSeries.objects.create(owner=pasi_user)
+def test_old_series_are_pruned(staff_api_client, staff_user):
+    new_permit_series = PermitSeries.objects.create(active=False, owner=staff_user)
+    old_permit_series = PermitSeries.objects.create(owner=staff_user)
     old_permit_series.created_at = timezone.now() - datetime.timedelta(3)
     old_permit_series.save()
 

--- a/parkings/tests/conftest.py
+++ b/parkings/tests/conftest.py
@@ -4,8 +4,8 @@ from pytest_factoryboy import register
 from parkings.factories import (
     ActivePermitFactory, AdminUserFactory, DiscParkingFactory,
     HistoryParkingFactory, OperatorFactory, ParkingAreaFactory, ParkingFactory,
-    PasiUserFactory, PermitFactory, PermitSeriesFactory, RegionFactory,
-    StaffUserFactory, UserFactory)
+    PermitFactory, PermitSeriesFactory, RegionFactory, StaffUserFactory,
+    UserFactory)
 
 register(OperatorFactory)
 register(ParkingFactory, 'parking')
@@ -14,7 +14,6 @@ register(AdminUserFactory, 'admin_user')
 register(StaffUserFactory, 'staff_user')
 register(UserFactory)
 register(ParkingAreaFactory)
-register(PasiUserFactory)
 register(RegionFactory)
 register(PermitFactory, 'permit')
 register(PermitSeriesFactory, 'permit_series')


### PR DESCRIPTION
Pasi user in data migration is staff.

Pasi user factory is not needed as staff user can be an owner of
Permitseries.