### PR TITLE
Permitted user for PermitArea

### DIFF
--- a/parkings/importers/geojson_permit_areas.py
+++ b/parkings/importers/geojson_permit_areas.py
@@ -1,6 +1,7 @@
 import logging
 import os
 
+from django.contrib.auth import get_user_model
 from django.db import transaction
 
 from parkings.models import PermitArea
@@ -16,19 +17,20 @@ class PermitAreaImporter(GeoJsonImporter):
     Imports permit area data
     """
 
-    def import_permit_areas(self, geojson_file_path):
+    def import_permit_areas(self, geojson_file_path, permitted_user):
         permit_area_dicts = self.read_and_parse(geojson_file_path)
-        count = self._save_permit_areas(permit_area_dicts)
+        count = self._save_permit_areas(permit_area_dicts, permitted_user)
         logger.info('Created or updated {} permit areas'.format(count))
 
     @transaction.atomic
-    def _save_permit_areas(self, permit_areas_dict):
+    def _save_permit_areas(self, permit_areas_dict, permitted_user):
         logger.info('Saving permit areas.')
         count = 0
         permit_area_ids = []
         for area_dict in permit_areas_dict:
             permit_area, _ = PermitArea.objects.update_or_create(
                 identifier=area_dict['identifier'],
+                permitted_user=get_user_model().objects.filter(username=permitted_user).get(),
                 defaults=area_dict)
             permit_area_ids.append(permit_area.pk)
             count += 1

--- a/parkings/management/commands/import_geojson_permit_areas.py
+++ b/parkings/management/commands/import_geojson_permit_areas.py
@@ -8,7 +8,9 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('geojson_file_path')
+        parser.add_argument('permitted-user')
 
     def handle(self, *args, **options):
         file_path = options.get('geojson_file_path', None)
-        PermitAreaImporter().import_permit_areas(file_path)
+        permitted_user = options.get('permitted-user', None)
+        PermitAreaImporter().import_permit_areas(file_path, permitted_user)

--- a/parkings/migrations/0029_enforcement_domain.py
+++ b/parkings/migrations/0029_enforcement_domain.py
@@ -102,6 +102,12 @@ class Migration(migrations.Migration):
             name='domain',
             field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, related_name='permit_areas', to='parkings.EnforcementDomain'),
         ),
+        migrations.AddField(
+            model_name='permitarea',
+            name='permitted_user',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT,
+                                    verbose_name='permitted_user', to=settings.AUTH_USER_MODEL),
+        ),
         migrations.AlterUniqueTogether(
             name='permitarea',
             unique_together={('domain', 'identifier')},

--- a/parkings/migrations/0030_domain_data.py
+++ b/parkings/migrations/0030_domain_data.py
@@ -31,7 +31,8 @@ def _set_domains(apps, schema_editor):
 
     permit_areas = permit_area_model.objects.filter(domain=None)
     if permit_areas.exists():
-        permit_areas.update(domain=_get_or_create_enforcement_domain(apps))
+        permit_areas.update(domain=_get_or_create_enforcement_domain(apps),
+                            permitted_user=_get_or_create_pasi_user(apps))
 
     payment_zones = payment_zone_model.objects.filter(domain=None)
     if payment_zones.exists():
@@ -46,7 +47,7 @@ def _set_permitseries_owner(apps, schema_editor):
     permit_series_model = apps.get_model('parkings', 'PermitSeries')
     permit_series = permit_series_model.objects.filter(owner=None)
     if permit_series.exists():
-        permit_series.update(owner=_get_or_create_permit_owner(apps))
+        permit_series.update(owner=_get_or_create_pasi_user(apps))
 
 
 def _create_enforcer_for_user(apps, schema_editor):
@@ -67,7 +68,7 @@ def _get_or_create_enforcer(apps, user):
     return enforcer
 
 
-def _get_or_create_permit_owner(apps):
+def _get_or_create_pasi_user(apps):
     user_model = apps.get_model(settings.AUTH_USER_MODEL)
     permit_owner, created = user_model.objects.get_or_create(
         username='PASI',

--- a/parkings/migrations/0031_default_domain.py
+++ b/parkings/migrations/0031_default_domain.py
@@ -61,4 +61,9 @@ class Migration(migrations.Migration):
             name='owner',
             field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to=settings.AUTH_USER_MODEL, verbose_name='owner'),
         ),
+        migrations.AlterField(
+            model_name='permitarea',
+            name='permitted_user',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to=settings.AUTH_USER_MODEL, verbose_name='permitted_user'),
+        ),
     ]

--- a/parkings/models/permit.py
+++ b/parkings/models/permit.py
@@ -22,6 +22,8 @@ class PermitArea(TimestampedModelMixin, UUIDPrimaryKeyMixin):
     identifier = models.CharField(max_length=10, verbose_name=_('identifier'))
     geom = gis_models.MultiPolygonField(
         srid=GK25FIN_SRID, verbose_name=_('geometry'))
+    permitted_user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.PROTECT, verbose_name=_("permitted_user"))
 
     class Meta:
         unique_together = [('domain', 'identifier')]

--- a/parkings/tests/api/enforcement/test_check_parking.py
+++ b/parkings/tests/api/enforcement/test_check_parking.py
@@ -89,9 +89,9 @@ def test_check_parking_invalid_zone_parking(operator, staff_api_client, parking_
     assert response.data["allowed"] is False
 
 
-def test_check_parking_valid_permit(staff_api_client, permit_series_factory):
+def test_check_parking_valid_permit(staff_api_client, permit_series_factory, staff_user):
     area = create_area_geom()
-    PermitArea.objects.create(name="Kamppi", identifier="A", geom=area)
+    PermitArea.objects.create(name="Kamppi", identifier="A", geom=area, permitted_user=staff_user)
     permit_series = permit_series_factory(active=True)
 
     end_time = timezone.now() + datetime.timedelta(days=1)
@@ -116,9 +116,9 @@ def test_check_parking_valid_permit(staff_api_client, permit_series_factory):
     assert response.data["allowed"] is True
 
 
-def test_check_parking_invalid_time_permit(staff_api_client, permit_series_factory):
+def test_check_parking_invalid_time_permit(staff_api_client, permit_series_factory, staff_user):
     area = create_area_geom()
-    PermitArea.objects.create(name="Kamppi", identifier="A", geom=area)
+    PermitArea.objects.create(name="Kamppi", identifier="A", geom=area, permitted_user=staff_user)
     permit_series = permit_series_factory(active=True)
 
     end_time = timezone.now()
@@ -143,9 +143,9 @@ def test_check_parking_invalid_time_permit(staff_api_client, permit_series_facto
     assert response.data["allowed"] is False
 
 
-def test_check_parking_invalid_location(staff_api_client, permit_series_factory):
+def test_check_parking_invalid_location(staff_api_client, permit_series_factory, staff_user):
     area = create_area_geom()
-    PermitArea.objects.create(name="Kamppi", identifier="A", geom=area)
+    PermitArea.objects.create(name="Kamppi", identifier="A", geom=area, permitted_user=staff_user)
     permit_series = permit_series_factory(active=True)
 
     end_time = timezone.now() + datetime.timedelta(days=1)

--- a/parkings/tests/test_geojson_importing_management_commands.py
+++ b/parkings/tests/test_geojson_importing_management_commands.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from django.contrib.auth import get_user_model
 from django.core.management import call_command
 
 from parkings.models import PaymentZone, PermitArea
@@ -22,6 +23,7 @@ def test_import_payment_zones():
 
 @pytest.mark.django_db
 def test_permit_area_importer():
-    call_command(import_geojson_permit_areas.Command(), permit_areas)
+    test_user = get_user_model().objects.create(username='TEST_USER', is_staff=True)
+    call_command(import_geojson_permit_areas.Command(), permit_areas, test_user.username)
 
     assert PermitArea.objects.count() == 1

--- a/parkkihubi_hel/importers/permit_areas.py
+++ b/parkkihubi_hel/importers/permit_areas.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.contrib.auth import get_user_model
 from django.db import transaction
 
 from parkings.models import EnforcementDomain, PermitArea
@@ -15,13 +16,13 @@ class PermitAreaImporter(WfsImporter):
     """
     wfs_typename = 'Asukas_ja_yrityspysakointivyohykkeet_alue'
 
-    def import_permit_areas(self):
+    def import_permit_areas(self, permitted_user):
         permit_area_dicts = self.download_and_parse()
-        count = self._save_permit_areas(permit_area_dicts)
+        count = self._save_permit_areas(permit_area_dicts, permitted_user)
         logger.info('Created or updated {} permit areas'.format(count))
 
     @transaction.atomic
-    def _save_permit_areas(self, permit_areas_dict):
+    def _save_permit_areas(self, permit_areas_dict, permitted_user):
         logger.info('Saving permit areas.')
         count = 0
         permit_area_ids = []
@@ -29,6 +30,7 @@ class PermitAreaImporter(WfsImporter):
             permit_area, _ = PermitArea.objects.update_or_create(
                 domain=EnforcementDomain.get_default_domain(),
                 identifier=area_dict['identifier'],
+                permitted_user=get_user_model().objects.filter(username=permitted_user).get(),
                 defaults=area_dict)
             permit_area_ids.append(permit_area.pk)
             count += 1

--- a/parkkihubi_hel/management/commands/import_permit_areas.py
+++ b/parkkihubi_hel/management/commands/import_permit_areas.py
@@ -6,5 +6,9 @@ from ...importers import PermitAreaImporter
 class Command(BaseCommand):
     help = 'Uses the PermitAreaImporter to create permit areas'
 
+    def add_arguments(self, parser):
+        parser.add_argument('permitted-user')
+
     def handle(self, *args, **options):
-        PermitAreaImporter().import_permit_areas()
+        permitted_user = options.get('permitted-user', None)
+        PermitAreaImporter().import_permit_areas(permitted_user)

--- a/parkkihubi_hel/tests/test_importing_management_commands.py
+++ b/parkkihubi_hel/tests/test_importing_management_commands.py
@@ -1,4 +1,5 @@
 import pytest
+from django.contrib.auth import get_user_model
 from django.core.management import call_command
 
 from parkings.models import ParkingArea, PaymentZone, PermitArea
@@ -29,7 +30,7 @@ def test_import_payment_zones():
 @pytest.mark.django_db
 def test_permit_area_importer():
     with mocked_requests():
-
-        call_command(import_permit_areas.Command())
+        test_user = get_user_model().objects.create(username='TEST_USER', is_staff=True)
+        call_command(import_permit_areas.Command(), test_user.username)
 
     assert PermitArea.objects.count() == 1


### PR DESCRIPTION
Add permitted_user a FK to User table in order to identify the Permit
area the user has access to read.

Update 3 migrations to reflect the change:
1. 0029_enforcement_domain add foreign key to User table from
PermitArea with default null

2. 0030_domain_data update PermitArea's permitted_user with PASI user
as default

3. 0031_default_domain update PermitArea for not to accept default
value as null

Update PermitArea and Geojson importer to pass permitted-user as an
argument.

Update test_geojson_importing_management_commands and
test_importing_management_commands to pass PASI user to be used as
permitted_user for PermitArea