### PR TITLE
Multicity endpoints

### DIFF
--- a/parkings/api/common_permit.py
+++ b/parkings/api/common_permit.py
@@ -101,6 +101,9 @@ class PermitViewSet(viewsets.ModelViewSet):
             kwargs['many'] = True
         return super().get_serializer(*args, **kwargs)
 
+    def get_queryset(self):
+        return super().get_queryset().filter(series__owner=self.request.user)
+
 
 class ActivePermitByExternalIdSerializer(PermitSerializer):
     class Meta(PermitSerializer.Meta):

--- a/parkings/api/common_permit.py
+++ b/parkings/api/common_permit.py
@@ -29,6 +29,9 @@ class PermitSeriesViewSet(CreateAndReadOnlyModelViewSet):
     queryset = PermitSeries.objects.all()
     serializer_class = PermitSeriesSerializer
 
+    def perform_create(self, serializer):
+        serializer.save(owner=self.request.user)
+
     @action(detail=True, methods=['post'])
     def activate(self, request, pk=None):
         with transaction.atomic():

--- a/parkings/api/common_permit.py
+++ b/parkings/api/common_permit.py
@@ -55,6 +55,9 @@ class PermitSeriesViewSet(CreateAndReadOnlyModelViewSet):
 
             return Response({'status': 'OK'})
 
+    def get_queryset(self):
+        return super().get_queryset().filter(owner=self.request.user)
+
 
 class PermitListSerializer(serializers.ListSerializer):
     def create(self, validated_data):

--- a/parkings/api/common_permit.py
+++ b/parkings/api/common_permit.py
@@ -1,0 +1,117 @@
+from django.db import transaction
+from django.utils.translation import gettext as _
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import mixins, permissions, serializers, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound
+from rest_framework.response import Response
+
+from ..models import EnforcementDomain, Permit, PermitSeries
+
+
+class PermitSeriesSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PermitSeries
+        fields = ['id', 'created_at', 'modified_at', 'active']
+        read_only_fields = fields
+
+
+class CreateAndReadOnlyModelViewSet(
+        mixins.CreateModelMixin,
+        mixins.RetrieveModelMixin,
+        mixins.ListModelMixin,
+        viewsets.GenericViewSet):
+    pass
+
+
+class PermitSeriesViewSet(CreateAndReadOnlyModelViewSet):
+    permission_classes = [permissions.IsAdminUser]
+    queryset = PermitSeries.objects.all()
+    serializer_class = PermitSeriesSerializer
+
+    @action(detail=True, methods=['post'])
+    def activate(self, request, pk=None):
+        with transaction.atomic():
+            obj_to_activate = self.get_object()
+            old_actives = self.queryset.filter(active=True)
+
+            if obj_to_activate.active and old_actives.count() == 1:
+                return Response({'status': 'No change'})
+
+            if not obj_to_activate.active:
+                obj_to_activate.active = True
+                obj_to_activate.save()
+
+            for obj in old_actives.exclude(pk=obj_to_activate.pk):
+                obj.active = False
+                obj.save()
+
+            prunable_series = PermitSeries.objects.prunable()
+            Permit.objects.filter(series__in=prunable_series).delete()
+            prunable_series.delete()
+
+            return Response({'status': 'OK'})
+
+
+class PermitListSerializer(serializers.ListSerializer):
+    def create(self, validated_data):
+        permits = [Permit(**item) for item in validated_data]
+        return Permit.objects.bulk_create(permits)
+
+
+class PermitSerializer(serializers.ModelSerializer):
+    class Meta:
+        list_serializer_class = PermitListSerializer
+        model = Permit
+        fields = [
+            'id',
+            'series',
+            'external_id',
+            'subjects',
+            'areas',
+        ]
+        read_only_fields = ['id']
+
+    def validate(self, attrs):
+        if self.instance is None:
+            if attrs.get('domain', None) is None:
+                attrs['domain'] = EnforcementDomain.get_default_domain()
+            instance = Permit(self.instance, **attrs)
+            instance.clean()
+        else:
+            instance = self.instance
+            for key in attrs:
+                setattr(instance, key, attrs[key])
+            instance.clean()
+        return super(PermitSerializer, self).validate(attrs)
+
+
+class PermitViewSet(viewsets.ModelViewSet):
+    permission_classes = [permissions.IsAdminUser]
+    queryset = Permit.objects.all()
+    serializer_class = PermitSerializer
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ['series', 'external_id']
+
+    def get_serializer(self, *args, **kwargs):
+        if isinstance(kwargs.get('data', {}), list):
+            kwargs['many'] = True
+        return super().get_serializer(*args, **kwargs)
+
+
+class ActivePermitByExternalIdSerializer(PermitSerializer):
+    class Meta(PermitSerializer.Meta):
+        read_only_fields = ['id', 'series']
+
+
+class ActivePermitByExternalIdViewSet(viewsets.ModelViewSet):
+    permission_classes = [permissions.IsAdminUser]
+    queryset = Permit.objects.active().exclude(external_id=None)
+    serializer_class = ActivePermitByExternalIdSerializer
+    lookup_field = 'external_id'
+
+    def perform_create(self, serializer):
+        latest_active_permit_series = PermitSeries.objects.latest_active()
+        if not latest_active_permit_series:
+            raise NotFound(_("Active permit series doesn't exist"))
+        serializer.save(series=latest_active_permit_series)

--- a/parkings/api/common_permit.py
+++ b/parkings/api/common_permit.py
@@ -121,3 +121,6 @@ class ActivePermitByExternalIdViewSet(viewsets.ModelViewSet):
         if not latest_active_permit_series:
             raise NotFound(_("Active permit series doesn't exist"))
         serializer.save(series=latest_active_permit_series)
+
+    def get_queryset(self):
+        return super().get_queryset().filter(series__owner=self.request.user)

--- a/parkings/api/enforcement/check_parking.py
+++ b/parkings/api/enforcement/check_parking.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib.gis.gdal.error import GDALException
 from django.contrib.gis.geos import Point
 from django.utils import timezone
+from django.utils.translation import ugettext_lazy as _
 from rest_framework import generics, permissions, serializers
 from rest_framework.response import Response
 
@@ -90,6 +91,10 @@ class CheckParking(generics.GenericAPIView):
             allowed=allowed,
             found_parking=parking,
         )
+
+        if parking and request.user.enforcer.enforced_domain != parking.domain:
+            # Enforcers cannot see parkings of another domain
+            return Response({'error': _('You do not have permission to view this parking')})
 
         return Response(result)
 

--- a/parkings/api/enforcement/permit.py
+++ b/parkings/api/enforcement/permit.py
@@ -1,117 +1,16 @@
-from django.db import transaction
-from django.utils.translation import gettext as _
-from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import mixins, permissions, serializers, viewsets
-from rest_framework.decorators import action
-from rest_framework.exceptions import NotFound
-from rest_framework.response import Response
-
-from ...models import EnforcementDomain, Permit, PermitSeries
+from ..common_permit import (
+    ActivePermitByExternalIdViewSet, PermitSeriesViewSet, PermitViewSet)
 
 
-class PermitSeriesSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = PermitSeries
-        fields = ['id', 'created_at', 'modified_at', 'active']
-        read_only_fields = fields
-
-
-class CreateAndReadOnlyModelViewSet(
-        mixins.CreateModelMixin,
-        mixins.RetrieveModelMixin,
-        mixins.ListModelMixin,
-        viewsets.GenericViewSet):
+class EnforcementPermitSeriesViewSet(PermitSeriesViewSet):
     pass
 
 
-class PermitSeriesViewSet(CreateAndReadOnlyModelViewSet):
-    permission_classes = [permissions.IsAdminUser]
-    queryset = PermitSeries.objects.all()
-    serializer_class = PermitSeriesSerializer
-
-    @action(detail=True, methods=['post'])
-    def activate(self, request, pk=None):
-        with transaction.atomic():
-            obj_to_activate = self.get_object()
-            old_actives = self.queryset.filter(active=True)
-
-            if obj_to_activate.active and old_actives.count() == 1:
-                return Response({'status': 'No change'})
-
-            if not obj_to_activate.active:
-                obj_to_activate.active = True
-                obj_to_activate.save()
-
-            for obj in old_actives.exclude(pk=obj_to_activate.pk):
-                obj.active = False
-                obj.save()
-
-            prunable_series = PermitSeries.objects.prunable()
-            Permit.objects.filter(series__in=prunable_series).delete()
-            prunable_series.delete()
-
-            return Response({'status': 'OK'})
+class EnforcementPermitViewSet(PermitViewSet):
+    pass
 
 
-class PermitListSerializer(serializers.ListSerializer):
-    def create(self, validated_data):
-        permits = [Permit(**item) for item in validated_data]
-        return Permit.objects.bulk_create(permits)
-
-
-class PermitSerializer(serializers.ModelSerializer):
-    class Meta:
-        list_serializer_class = PermitListSerializer
-        model = Permit
-        fields = [
-            'id',
-            'series',
-            'external_id',
-            'subjects',
-            'areas',
-        ]
-        read_only_fields = ['id']
-
-    def validate(self, attrs):
-        if self.instance is None:
-            if attrs.get('domain', None) is None:
-                attrs['domain'] = EnforcementDomain.get_default_domain()
-            instance = Permit(self.instance, **attrs)
-            instance.clean()
-        else:
-            instance = self.instance
-            for key in attrs:
-                setattr(instance, key, attrs[key])
-            instance.clean()
-        return super(PermitSerializer, self).validate(attrs)
-
-
-class PermitViewSet(viewsets.ModelViewSet):
-    permission_classes = [permissions.IsAdminUser]
-    queryset = Permit.objects.all()
-    serializer_class = PermitSerializer
-    filter_backends = [DjangoFilterBackend]
-    filterset_fields = ['series', 'external_id']
-
-    def get_serializer(self, *args, **kwargs):
-        if isinstance(kwargs.get('data', {}), list):
-            kwargs['many'] = True
-        return super().get_serializer(*args, **kwargs)
-
-
-class ActivePermitByExternalIdSerializer(PermitSerializer):
-    class Meta(PermitSerializer.Meta):
-        read_only_fields = ['id', 'series']
-
-
-class ActivePermitByExternalIdViewSet(viewsets.ModelViewSet):
-    permission_classes = [permissions.IsAdminUser]
-    queryset = Permit.objects.active().exclude(external_id=None)
-    serializer_class = ActivePermitByExternalIdSerializer
-    lookup_field = 'external_id'
-
-    def perform_create(self, serializer):
-        latest_active_permit_series = PermitSeries.objects.latest_active()
-        if not latest_active_permit_series:
-            raise NotFound(_("Active permit series doesn't exist"))
-        serializer.save(series=latest_active_permit_series)
+class EnforcementActivePermitByExternalIdViewSet(
+    ActivePermitByExternalIdViewSet
+):
+    pass

--- a/parkings/api/enforcement/urls.py
+++ b/parkings/api/enforcement/urls.py
@@ -5,7 +5,8 @@ from ..url_utils import versioned_url
 from .check_parking import CheckParking
 from .operator import OperatorViewSet
 from .permit import (
-    ActivePermitByExternalIdViewSet, PermitSeriesViewSet, PermitViewSet)
+    EnforcementActivePermitByExternalIdViewSet, EnforcementPermitSeriesViewSet,
+    EnforcementPermitViewSet)
 from .valid_parking import ValidParkingViewSet
 
 
@@ -24,10 +25,10 @@ class Router(DefaultRouter):
 
 router = Router()
 router.register('operator', OperatorViewSet, basename='operator')
-router.register('permit', PermitViewSet, basename='permit')
+router.register('permit', EnforcementPermitViewSet, basename='permit')
 router.register('active_permit_by_external_id',
-                ActivePermitByExternalIdViewSet, basename='activepermit')
-router.register('permitseries', PermitSeriesViewSet, basename='permitseries')
+                EnforcementActivePermitByExternalIdViewSet, basename='activepermit')
+router.register('permitseries', EnforcementPermitSeriesViewSet, basename='permitseries')
 router.register('valid_parking', ValidParkingViewSet,
                 basename='valid_parking')
 

--- a/parkings/api/enforcement/valid_parking.py
+++ b/parkings/api/enforcement/valid_parking.py
@@ -136,6 +136,9 @@ class ValidParkingViewSet(viewsets.ReadOnlyModelViewSet):
         filter_backend = self.filter_backends[0]()
         return filter_backend.get_filterset(self.request, queryset, self)
 
+    def get_queryset(self):
+        return super().get_queryset().filter(domain=self.request.user.enforcer.enforced_domain)
+
 
 def get_grace_duration(default=datetime.timedelta(minutes=15)):
     value = getattr(settings, 'PARKKIHUBI_TIME_OLD_PARKINGS_VISIBLE', None)

--- a/parkings/api/operator/enforcement_domain.py
+++ b/parkings/api/operator/enforcement_domain.py
@@ -1,0 +1,19 @@
+from rest_framework import serializers
+from rest_framework.mixins import ListModelMixin
+from rest_framework.viewsets import GenericViewSet
+
+from parkings.models import EnforcementDomain
+
+from .operator_permission import OperatorApiHasPermission
+
+
+class EnforcementDomainSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = EnforcementDomain
+        fields = ("code", "name")
+
+
+class EnforcementDomainViewSet(ListModelMixin, GenericViewSet):
+    permission_classes = [OperatorApiHasPermission]
+    serializer_class = EnforcementDomainSerializer
+    queryset = EnforcementDomain.objects.all()

--- a/parkings/api/operator/operator_permission.py
+++ b/parkings/api/operator/operator_permission.py
@@ -1,0 +1,22 @@
+from rest_framework import permissions
+
+from parkings.models import Operator
+
+
+class OperatorApiHasPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        """
+        Allow only operators to proceed further.
+        """
+        user = request.user
+
+        if not user.is_authenticated:
+            return False
+
+        try:
+            user.operator
+            return True
+        except Operator.DoesNotExist:
+            pass
+
+        return False

--- a/parkings/api/operator/parking.py
+++ b/parkings/api/operator/parking.py
@@ -2,11 +2,12 @@ import pytz
 from django.conf import settings
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
-from rest_framework import mixins, permissions, serializers, viewsets
+from rest_framework import mixins, serializers, viewsets
 
-from parkings.models import Operator, Parking
+from parkings.models import Parking
 
 from ..common import ParkingException
+from .operator_permission import OperatorApiHasPermission
 
 
 class OperatorAPIParkingSerializer(serializers.ModelSerializer):
@@ -75,24 +76,7 @@ class OperatorAPIParkingSerializer(serializers.ModelSerializer):
         return representation
 
 
-class OperatorAPIParkingPermission(permissions.BasePermission):
-    def has_permission(self, request, view):
-        """
-        Allow only operators to create/modify a parking.
-        """
-        user = request.user
-
-        if not user.is_authenticated:
-            return False
-
-        try:
-            user.operator
-            return True
-        except Operator.DoesNotExist:
-            pass
-
-        return False
-
+class OperatorAPIParkingPermission(OperatorApiHasPermission):
     def has_object_permission(self, request, view, obj):
         """
         Allow operators to modify only their own parkings.

--- a/parkings/api/operator/permit.py
+++ b/parkings/api/operator/permit.py
@@ -2,7 +2,9 @@ from rest_framework import serializers
 
 from parkings.models import EnforcementDomain
 
-from ..common_permit import PermitSerializer, PermitViewSet
+from ..common_permit import (
+    ActivePermitByExternalIdSerializer, ActivePermitByExternalIdViewSet,
+    PermitSerializer, PermitViewSet)
 from .operator_permission import OperatorApiHasPermission
 
 
@@ -17,3 +19,16 @@ class OperatorPermitSerializer(PermitSerializer):
 class OperatorPermitViewSet(PermitViewSet):
     serializer_class = OperatorPermitSerializer
     permission_classes = [OperatorApiHasPermission]
+
+
+class OperatorActivePermitByExtIdSerializer(ActivePermitByExternalIdSerializer):
+    domain = serializers.SlugRelatedField(
+        slug_field='code', queryset=EnforcementDomain.objects.all())
+
+    class Meta(ActivePermitByExternalIdSerializer.Meta):
+        fields = ActivePermitByExternalIdSerializer.Meta.fields + ['domain']
+
+
+class OperatorActivePermitByExternalIdViewSet(ActivePermitByExternalIdViewSet):
+    permission_classes = [OperatorApiHasPermission]
+    serializer_class = OperatorActivePermitByExtIdSerializer

--- a/parkings/api/operator/permit.py
+++ b/parkings/api/operator/permit.py
@@ -1,6 +1,10 @@
+from django.db import transaction
+from django.utils.translation import ugettext_lazy as _
 from rest_framework import mixins, serializers
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
-from parkings.models import EnforcementDomain
+from parkings.models import EnforcementDomain, Permit, PermitSeries
 
 from ..common_permit import (
     ActivePermitByExternalIdSerializer, ActivePermitByExternalIdViewSet,
@@ -36,3 +40,53 @@ class OperatorActivePermitByExternalIdViewSet(ActivePermitByExternalIdViewSet):
 
 class OperatorPermitSeriesViewSet(mixins.DestroyModelMixin, PermitSeriesViewSet):
     permission_classes = [OperatorApiHasPermission]
+
+    @action(detail=True, methods=['post'])
+    def activate(self, request, pk=None):
+        with transaction.atomic():
+            obj_to_activate = self.get_object()
+            old_actives = self.queryset.filter(active=True)
+
+            # Always activate the specified permit series regardless of what to deactivate
+            if not obj_to_activate.active:
+                obj_to_activate.active = True
+                obj_to_activate.save()
+
+            deactivate_payload = OperatorPermitSeriesPayload(data=request.data)
+            deactivate_payload.is_valid(raise_exception=True)
+            validated_data = deactivate_payload.validated_data
+
+            if validated_data['deactivate_others']:
+                old_actives.exclude(pk=obj_to_activate.pk).update(active=False)
+            else:
+                ids_to_deactivate = validated_data.get('deactivate_series', [])
+                old_actives.filter(id__in=ids_to_deactivate).exclude(
+                    pk=obj_to_activate.pk
+                ).update(active=False)
+
+            prunable_series = PermitSeries.objects.prunable()
+            Permit.objects.filter(series__in=prunable_series).delete()
+            prunable_series.delete()
+
+            return Response({'status': 'OK'})
+
+
+class OperatorPermitSeriesPayload(serializers.Serializer):
+    deactivate_others = serializers.BooleanField(required=False)
+    deactivate_series = serializers.ListField(
+        child=serializers.IntegerField(), required=False
+    )
+
+    def validate(self, data):
+        if 'deactivate_series' in data:
+            data['deactivate_others'] = False
+
+        if (
+            'deactivate_others' in data
+            or 'deactivate_series' in data
+        ):
+            return super().validate(data)
+
+        raise serializers.ValidationError(
+            _('Either deactivate_others or deactivate_series is required')
+        )

--- a/parkings/api/operator/permit.py
+++ b/parkings/api/operator/permit.py
@@ -1,10 +1,10 @@
-from rest_framework import serializers
+from rest_framework import mixins, serializers
 
 from parkings.models import EnforcementDomain
 
 from ..common_permit import (
     ActivePermitByExternalIdSerializer, ActivePermitByExternalIdViewSet,
-    PermitSerializer, PermitViewSet)
+    PermitSerializer, PermitSeriesViewSet, PermitViewSet)
 from .operator_permission import OperatorApiHasPermission
 
 
@@ -32,3 +32,7 @@ class OperatorActivePermitByExtIdSerializer(ActivePermitByExternalIdSerializer):
 class OperatorActivePermitByExternalIdViewSet(ActivePermitByExternalIdViewSet):
     permission_classes = [OperatorApiHasPermission]
     serializer_class = OperatorActivePermitByExtIdSerializer
+
+
+class OperatorPermitSeriesViewSet(mixins.DestroyModelMixin, PermitSeriesViewSet):
+    permission_classes = [OperatorApiHasPermission]

--- a/parkings/api/operator/permit.py
+++ b/parkings/api/operator/permit.py
@@ -1,0 +1,19 @@
+from rest_framework import serializers
+
+from parkings.models import EnforcementDomain
+
+from ..common_permit import PermitSerializer, PermitViewSet
+from .operator_permission import OperatorApiHasPermission
+
+
+class OperatorPermitSerializer(PermitSerializer):
+    domain = serializers.SlugRelatedField(
+        slug_field='code', queryset=EnforcementDomain.objects.all())
+
+    class Meta(PermitSerializer.Meta):
+        fields = PermitSerializer.Meta.fields + ['domain']
+
+
+class OperatorPermitViewSet(PermitViewSet):
+    serializer_class = OperatorPermitSerializer
+    permission_classes = [OperatorApiHasPermission]

--- a/parkings/api/operator/urls.py
+++ b/parkings/api/operator/urls.py
@@ -3,12 +3,14 @@ from rest_framework.routers import DefaultRouter
 from ..url_utils import versioned_url
 from .enforcement_domain import EnforcementDomainViewSet
 from .parking import OperatorAPIParkingViewSet
-from .permit import OperatorPermitViewSet
+from .permit import (
+    OperatorActivePermitByExternalIdViewSet, OperatorPermitViewSet)
 
 router = DefaultRouter()
 router.register(r'parking', OperatorAPIParkingViewSet, basename='parking')
 router.register(r'enforcement_domain', EnforcementDomainViewSet, basename='enforcement_domain')
 router.register(r'permit', OperatorPermitViewSet, basename='permit')
+router.register(r'activepermit', OperatorActivePermitByExternalIdViewSet, basename='activepermit')
 
 app_name = 'operator'
 urlpatterns = [

--- a/parkings/api/operator/urls.py
+++ b/parkings/api/operator/urls.py
@@ -1,10 +1,12 @@
 from rest_framework.routers import DefaultRouter
 
 from ..url_utils import versioned_url
+from .enforcement_domain import EnforcementDomainViewSet
 from .parking import OperatorAPIParkingViewSet
 
 router = DefaultRouter()
 router.register(r'parking', OperatorAPIParkingViewSet, basename='parking')
+router.register(r'enforcement_domain', EnforcementDomainViewSet, basename='enforcement_domain')
 
 app_name = 'operator'
 urlpatterns = [

--- a/parkings/api/operator/urls.py
+++ b/parkings/api/operator/urls.py
@@ -3,10 +3,12 @@ from rest_framework.routers import DefaultRouter
 from ..url_utils import versioned_url
 from .enforcement_domain import EnforcementDomainViewSet
 from .parking import OperatorAPIParkingViewSet
+from .permit import OperatorPermitViewSet
 
 router = DefaultRouter()
 router.register(r'parking', OperatorAPIParkingViewSet, basename='parking')
 router.register(r'enforcement_domain', EnforcementDomainViewSet, basename='enforcement_domain')
+router.register(r'permit', OperatorPermitViewSet, basename='permit')
 
 app_name = 'operator'
 urlpatterns = [

--- a/parkings/api/operator/urls.py
+++ b/parkings/api/operator/urls.py
@@ -4,7 +4,7 @@ from ..url_utils import versioned_url
 from .parking import OperatorAPIParkingViewSet
 
 router = DefaultRouter()
-router.register(r'parking', OperatorAPIParkingViewSet)
+router.register(r'parking', OperatorAPIParkingViewSet, basename='parking')
 
 app_name = 'operator'
 urlpatterns = [

--- a/parkings/api/operator/urls.py
+++ b/parkings/api/operator/urls.py
@@ -4,13 +4,15 @@ from ..url_utils import versioned_url
 from .enforcement_domain import EnforcementDomainViewSet
 from .parking import OperatorAPIParkingViewSet
 from .permit import (
-    OperatorActivePermitByExternalIdViewSet, OperatorPermitViewSet)
+    OperatorActivePermitByExternalIdViewSet, OperatorPermitSeriesViewSet,
+    OperatorPermitViewSet)
 
 router = DefaultRouter()
 router.register(r'parking', OperatorAPIParkingViewSet, basename='parking')
 router.register(r'enforcement_domain', EnforcementDomainViewSet, basename='enforcement_domain')
 router.register(r'permit', OperatorPermitViewSet, basename='permit')
 router.register(r'activepermit', OperatorActivePermitByExternalIdViewSet, basename='activepermit')
+router.register(r'permitseries', OperatorPermitSeriesViewSet, basename='permitseries')
 
 app_name = 'operator'
 urlpatterns = [

--- a/parkings/factories/__init__.py
+++ b/parkings/factories/__init__.py
@@ -1,3 +1,4 @@
+from .enforcement_domain import EnforcementDomainFactory, EnforcerFactory
 from .operator import OperatorFactory  # noqa
 from .parking import (  # noqa
     DiscParkingFactory, HistoryParkingFactory, ParkingFactory)
@@ -19,4 +20,6 @@ __all__ = [
     'RegionFactory',
     'StaffUserFactory',
     'UserFactory',
+    'EnforcementDomainFactory',
+    'EnforcerFactory',
 ]

--- a/parkings/factories/enforcement_domain.py
+++ b/parkings/factories/enforcement_domain.py
@@ -1,0 +1,23 @@
+import factory
+
+from parkings.models import EnforcementDomain, Enforcer
+
+from .faker import fake
+from .user import StaffUserFactory
+
+
+class EnforcementDomainFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = EnforcementDomain
+
+    name = factory.LazyFunction(fake.city)
+    code = factory.Sequence(lambda n: 'DMN%d' % (n + 1))
+
+
+class EnforcerFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Enforcer
+
+    name = factory.LazyFunction(fake.name)
+    user = factory.SubFactory(StaffUserFactory)
+    enforced_domain = factory.SubFactory(EnforcementDomainFactory)

--- a/parkings/tests/api/conftest.py
+++ b/parkings/tests/api/conftest.py
@@ -57,3 +57,8 @@ def operator_2_api_client(operator_2):
     token_authenticate(api_client, operator_2.user)
     api_client.operator = operator_2
     return api_client
+
+
+@pytest.fixture
+def staff_enforcer(enforcer_factory, staff_user):
+    return enforcer_factory(user=staff_user)

--- a/parkings/tests/api/enforcement/test_active_permit_by_external_id.py
+++ b/parkings/tests/api/enforcement/test_active_permit_by_external_id.py
@@ -9,8 +9,14 @@ from ....factories.permit import (
 list_url = reverse('enforcement:v1:activepermit-list')
 
 
+def change_permitseries_owner_to(permit_series, owner):
+    permit_series.owner = owner
+    permit_series.save()
+
+
 @pytest.mark.django_db
-def test_post_active_permit_by_external_id(staff_api_client, permit_series):
+def test_post_active_permit_by_external_id(staff_api_client, permit_series, staff_user):
+    permit_series.owner = staff_user
     permit_series.active = True
     permit_series.save()
     data = {
@@ -26,7 +32,8 @@ def test_post_active_permit_by_external_id(staff_api_client, permit_series):
 
 
 @pytest.mark.django_db
-def test_patch_active_permit_by_external_id(staff_api_client, active_permit):
+def test_patch_active_permit_by_external_id(staff_api_client, active_permit, staff_user):
+    change_permitseries_owner_to(active_permit.series, staff_user)
     areas = generate_areas()
     areas[0].update(area='X1')
     active_permit_by_external_id_url = '{}{}/'.format(list_url, active_permit.external_id)
@@ -38,7 +45,8 @@ def test_patch_active_permit_by_external_id(staff_api_client, active_permit):
 
 
 @pytest.mark.django_db
-def test_put_active_permit_by_external_id(staff_api_client, active_permit):
+def test_put_active_permit_by_external_id(staff_api_client, active_permit, staff_user):
+    change_permitseries_owner_to(active_permit.series, staff_user)
     areas = generate_areas(count=2)
     response = staff_api_client.get(list_url)
     put_data = response.data['results'][0]
@@ -65,7 +73,8 @@ def test_post_active_permit_by_external_id_fails_if_no_active_series_exists(staf
     assert response.data == {'detail': "Active permit series doesn't exist"}
 
 
-def test_invalid_put_active_permit_by_external_id(staff_api_client, active_permit):
+def test_invalid_put_active_permit_by_external_id(staff_api_client, active_permit, staff_user):
+    change_permitseries_owner_to(active_permit.series, staff_user)
     areas = generate_areas()
     del areas[0]['start_time']
     response = staff_api_client.get(list_url)
@@ -79,7 +88,8 @@ def test_invalid_put_active_permit_by_external_id(staff_api_client, active_permi
     assert set(response.data.keys()) == {'areas'}
 
 
-def test_invalid_patch_active_permit_by_external_id(staff_api_client, active_permit):
+def test_invalid_patch_active_permit_by_external_id(staff_api_client, active_permit, staff_user):
+    change_permitseries_owner_to(active_permit.series, staff_user)
     areas = generate_areas()
     del areas[0]['start_time']
     active_permit_by_external_id_url = '{}{}/'.format(list_url, active_permit.external_id)
@@ -90,7 +100,8 @@ def test_invalid_patch_active_permit_by_external_id(staff_api_client, active_per
     assert set(response.data.keys()) == {'areas'}
 
 
-def test_get_active_permit_by_external_id(staff_api_client, active_permit, permit):
+def test_get_active_permit_by_external_id(staff_api_client, active_permit, permit, staff_user):
+    change_permitseries_owner_to(active_permit.series, staff_user)
     response = staff_api_client.get(list_url)
 
     assert response.status_code == HTTP_200_OK

--- a/parkings/tests/api/enforcement/test_permit.py
+++ b/parkings/tests/api/enforcement/test_permit.py
@@ -5,7 +5,7 @@ from rest_framework.status import (
 
 from ....factories.permit import (
     generate_areas, generate_external_ids, generate_subjects)
-from ....models import Permit, PermitLookupItem
+from ....models import Permit, PermitLookupItem, PermitSeries
 
 list_url = reverse('enforcement:v1:permit-list')
 
@@ -273,3 +273,13 @@ def test_permit_bulk_create_normalizes_timestamps(
     assert permit2.subjects[0]['end_time'] == '2030-06-30T09:00:00+00:00'
     assert permit2.areas[0]['start_time'] == '1970-01-01T00:00:00+00:00'
     assert permit2.areas[0]['end_time'] == '2030-06-30T09:00:00+00:00'
+
+
+def test_permitseries_created_by_user_gets_the_user_as_owner(staff_api_client, staff_user):
+    url = reverse('enforcement:v1:permitseries-list')
+
+    response = staff_api_client.post(url, data={})
+
+    assert response.status_code == HTTP_201_CREATED
+    assert PermitSeries.objects.count() == 1
+    assert PermitSeries.objects.first().owner == staff_user

--- a/parkings/tests/api/enforcement/test_permit.py
+++ b/parkings/tests/api/enforcement/test_permit.py
@@ -168,7 +168,11 @@ def test_lookup_item_is_created_for_permit(staff_api_client, permit_series):
     assert PermitLookupItem.objects.count() == 1
 
 
-def test_api_endpoint_returns_correct_data(staff_api_client, permit):
+def test_api_endpoint_returns_correct_data(staff_api_client, permit, staff_user):
+    permit_series = permit.series
+    permit_series.owner = staff_user
+    permit_series.save()
+
     response = staff_api_client.get(list_url)
 
     assert response.status_code == HTTP_200_OK
@@ -189,7 +193,11 @@ def check_permit_areas_keys(data):
     assert set(data.keys()) == {'start_time', 'end_time', 'area'}
 
 
-def test_permit_data_matches_permit_object(staff_api_client, permit):
+def test_permit_data_matches_permit_object(staff_api_client, permit, staff_user):
+    permit_series = permit.series
+    permit_series.owner = staff_user
+    permit_series.save()
+
     permit_detail_url = '{}{}/'.format(list_url, permit.id)
 
     response = staff_api_client.get(permit_detail_url)

--- a/parkings/tests/api/operator/test_active_permit_by_external_id.py
+++ b/parkings/tests/api/operator/test_active_permit_by_external_id.py
@@ -1,0 +1,89 @@
+from django.urls import reverse
+from rest_framework.status import (
+    HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND)
+
+from parkings.models import Permit
+
+from ....factories.permit import (
+    generate_areas, generate_external_ids, generate_subjects)
+
+list_url = reverse('operator:v1:activepermit-list')
+
+
+def check_response_keys(response_data):
+    expected_keys = {
+        'id', 'domain', 'external_id',
+        'series', 'subjects', 'areas'
+    }
+
+    assert expected_keys == set(response_data.keys())
+
+
+def test_operator_can_post_active_permit_by_external_id(operator_api_client, active_permit):
+    data = {
+        'external_id': generate_external_ids(),
+        'subjects': generate_subjects(),
+        'areas': generate_areas(),
+        'domain': 'HKI',
+    }
+
+    response = operator_api_client.post(list_url, data=data)
+
+    assert response.status_code == HTTP_201_CREATED
+    assert response.json()['series'] == active_permit.series.id
+    check_response_keys(response.json())
+
+
+def test_operator_cannot_view_permit_in_active_series_owned_by_other_operator(
+    operator_api_client, active_permit, permit
+):
+    response = operator_api_client.get(list_url)
+
+    assert response.status_code == HTTP_200_OK
+    assert response.data['count'] == 0
+    assert Permit.objects.count() == 2
+
+
+def test_operator_can_only_view_permit_in_active_series_owned_by_themselves(
+    operator_api_client, active_permit, operator,
+    permit_series_factory, permit_factory, permit
+):
+    operator_owned_active_permitseries = permit_series_factory(active=True, owner=operator.user)
+    operator_permit = permit_factory(series=operator_owned_active_permitseries)
+
+    response = operator_api_client.get(list_url)
+
+    assert response.status_code == HTTP_200_OK
+    assert response.data['count'] == 1
+    assert Permit.objects.count() == 3
+    assert response.json()['results'][0]['id'] == operator_permit.id
+    assert response.json()['results'][0]['series'] == operator_owned_active_permitseries.id
+
+
+def get_active_permit_by_ext_id_detail_url(active_permit):
+    return reverse(
+        'operator:v1:activepermit-detail',
+        kwargs={'external_id': active_permit.external_id}
+    )
+
+
+def test_operator_can_only_delete_permit_in_active_series_owned_by_themselves(
+    operator_api_client, active_permit, permit, operator,
+    permit_series_factory, permit_factory
+):
+    url = get_active_permit_by_ext_id_detail_url(active_permit)
+
+    response = operator_api_client.delete(url)
+
+    assert response.status_code == HTTP_404_NOT_FOUND
+    assert Permit.objects.count() == 2
+
+    operator_owned_active_permitseries = permit_series_factory(active=True, owner=operator.user)
+    operator_permit = permit_factory(series=operator_owned_active_permitseries)
+
+    url = get_active_permit_by_ext_id_detail_url(operator_permit)
+
+    response = operator_api_client.delete(url)
+
+    assert response.status_code == HTTP_204_NO_CONTENT
+    assert not Permit.objects.filter(id=operator_permit.id).exists()

--- a/parkings/tests/api/operator/test_disc_parking.py
+++ b/parkings/tests/api/operator/test_disc_parking.py
@@ -29,7 +29,7 @@ expected_keys = {
         'terminal_number',
         'time_start', 'time_end',
         'location', 'created_at', 'modified_at',
-        'status', 'is_disc_parking',
+        'status', 'is_disc_parking', 'domain',
     }
 
 

--- a/parkings/tests/api/operator/test_enforcement_domain.py
+++ b/parkings/tests/api/operator/test_enforcement_domain.py
@@ -1,0 +1,15 @@
+from django.urls import reverse
+from rest_framework.status import HTTP_200_OK
+
+list_url = reverse('operator:v1:enforcement_domain-list')
+
+
+def test_enforcement_domain_list(operator_api_client, enforcement_domain):
+    response = operator_api_client.get(list_url)
+    json_response = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    assert json_response['count'] == 1
+    assert set(json_response['results'][0].keys()) == {'code', 'name'}
+    assert json_response['results'][0]['code'] == enforcement_domain.code
+    assert json_response['results'][0]['name'] == enforcement_domain.name

--- a/parkings/tests/api/operator/test_permit.py
+++ b/parkings/tests/api/operator/test_permit.py
@@ -1,0 +1,204 @@
+from django.urls import reverse
+from rest_framework.status import (
+    HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND)
+
+from parkings.models import Permit
+
+from ....factories.permit import (
+    generate_areas, generate_external_ids, generate_subjects)
+
+list_url = reverse('operator:v1:permit-list')
+
+
+def _get_detail_url(obj):
+    return reverse('operator:v1:permit-detail', kwargs={'pk': obj.pk})
+
+
+def _get_permit_data(permit_series):
+    return {
+        'series': permit_series.id,
+        'external_id': generate_external_ids(),
+        'subjects': generate_subjects(),
+        'areas': generate_areas(),
+    }
+
+
+def _check_response(data, obj):
+    permit_response_keys = {
+        'series',
+        'domain',
+        'external_id',
+        'id',
+        'subjects',
+        'areas',
+    }
+
+    assert set(data.keys()) == permit_response_keys
+    assert obj.series.pk == data['series']
+    assert obj.domain.code == data['domain']
+    assert obj.external_id == data['external_id']
+    assert obj.id == data['id']
+    assert obj.subjects == data['subjects']
+    assert obj.areas == data['areas']
+
+
+def test_operator_can_create_permit_with_valid_post_data(
+    operator_api_client, permit_series, enforcement_domain
+):
+    permit_data = _get_permit_data(permit_series)
+    permit_data.update(domain=enforcement_domain.code)
+
+    response = operator_api_client.post(list_url, data=permit_data)
+
+    assert response.status_code == HTTP_201_CREATED
+    _check_response(response.json(), Permit.objects.first())
+
+
+def test_operator_cannot_view_permit_owned_by_other_operator(
+    operator_api_client, operator_2_api_client, operator,
+    operator_2, permit_series_factory, permit_factory,
+):
+    operator1_owned_permitseries = permit_series_factory(owner=operator.user)
+    operator2_owned_permitseries = permit_series_factory(owner=operator_2.user)
+
+    operator1_permit_list = [permit_factory(series=operator1_owned_permitseries) for _ in range(3)]
+    operator2_permit_list = [permit_factory(series=operator2_owned_permitseries) for _ in range(3)]
+
+    response = operator_api_client.get(list_url)
+    json_response = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    assert json_response['count'] == 3
+    assert Permit.objects.count() == 6
+    assert set([permit['id'] for permit in json_response['results']]) == set(
+        [permit.id for permit in operator1_permit_list]
+    )
+
+    operator_permit_response_obj = [
+        permit
+        for permit in json_response['results']
+        if permit['id'] == operator1_permit_list[0].id
+    ][0]
+    _check_response(operator_permit_response_obj, operator1_permit_list[0])
+
+    response = operator_2_api_client.get(list_url)
+    json_response = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    assert json_response['count'] == 3
+    assert set([permit['id'] for permit in json_response['results']]) == set(
+        [permit.id for permit in operator2_permit_list]
+    )
+
+    operator2_permit_response_obj = [
+        permit
+        for permit in json_response['results']
+        if permit['id'] == operator2_permit_list[0].id
+    ][0]
+    _check_response(operator2_permit_response_obj, operator2_permit_list[0])
+
+
+def test_operator_cannot_modify_permit_owned_by_other_operator(
+    operator_api_client, operator, operator_2,
+    permit_series_factory, permit_factory
+):
+    operator1_owned_permitseries = permit_series_factory(owner=operator.user)
+    operator2_owned_permitseries = permit_series_factory(owner=operator_2.user)
+
+    operator1_permit_list = [permit_factory(series=operator1_owned_permitseries) for _ in range(3)]
+    operator2_permit_list = [permit_factory(series=operator2_owned_permitseries) for _ in range(3)]
+
+    operator1_permit = operator1_permit_list[0]
+    operator2_permit = operator2_permit_list[0]
+    patch_data = {'external_id': 'ABC123'}
+
+    response = operator_api_client.patch(
+        _get_detail_url(operator2_permit), data=patch_data
+    )
+
+    assert response.status_code == HTTP_404_NOT_FOUND
+
+    response = operator_api_client.patch(
+        _get_detail_url(operator1_permit), data=patch_data
+    )
+
+    assert response.status_code == HTTP_200_OK
+    assert response.json()['external_id'] == 'ABC123'
+
+
+def test_operator_cannot_delete_permit_owned_by_other_operator(
+    operator_api_client, operator, operator_2,
+    permit_series_factory, permit_factory
+):
+    operator1_owned_permitseries = permit_series_factory(owner=operator.user)
+    operator2_owned_permitseries = permit_series_factory(owner=operator_2.user)
+
+    operator1_permit_list = [permit_factory(series=operator1_owned_permitseries) for _ in range(3)]
+    operator2_permit_list = [permit_factory(series=operator2_owned_permitseries) for _ in range(3)]
+
+    operator1_permit = operator1_permit_list[0]
+    operator2_permit = operator2_permit_list[0]
+
+    response = operator_api_client.delete(
+        _get_detail_url(operator2_permit)
+    )
+
+    assert response.status_code == HTTP_404_NOT_FOUND
+    assert Permit.objects.count() == 6
+
+    response = operator_api_client.delete(
+        _get_detail_url(operator1_permit)
+    )
+
+    assert response.status_code == HTTP_204_NO_CONTENT
+    assert Permit.objects.count() == 5
+    assert not Permit.objects.filter(id=operator1_permit.id).exists()
+
+
+def test_operator_and_enforcers_cannot_see_each_others_permit(
+    operator_api_client, permit_series_factory, operator, staff_api_client,
+    staff_user, permit_factory, enforcement_domain, enforcer_factory
+):
+    reg_number = 'ABC-123'
+    permit_subject = generate_subjects()
+    permit_subject[0].update(registration_number=reg_number)
+
+    operator_permitseries = permit_series_factory(owner=operator.user)
+    enforcer_permitseries = permit_series_factory(owner=staff_user)
+
+    enforcer_permit_list = [
+        permit_factory(subjects=permit_subject, series=enforcer_permitseries)
+        for _
+        in range(3)
+    ]
+    enforcer_default_domain = enforcer_permit_list[0].domain
+    enforcer_factory(user=staff_user, enforced_domain=enforcer_default_domain)
+
+    operator_permit_domain = [enforcement_domain, enforcer_default_domain]
+    operator_permit_list = [
+        permit_factory(subjects=permit_subject, domain=domain, series=operator_permitseries)
+        for domain
+        in operator_permit_domain
+        ]
+
+    #  Operator should see only operator_permit_list
+    response = operator_api_client.get(list_url)
+    json_response = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    assert json_response['count'] == 2
+    assert set([permit['id'] for permit in json_response['results']]) == set(
+        [permit.id for permit in operator_permit_list]
+    )
+
+    enforcement_permit_url = reverse('enforcement:v1:permit-list')
+
+    #  Enforcer should see only enforcer_permit_list
+    response = staff_api_client.get(enforcement_permit_url)
+    json_response = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    assert json_response['count'] == 3
+    assert set([permit['id'] for permit in json_response['results']]) == set(
+        [permit.id for permit in enforcer_permit_list]
+    )

--- a/parkings/tests/api/operator/test_permit_series.py
+++ b/parkings/tests/api/operator/test_permit_series.py
@@ -1,0 +1,48 @@
+from django.urls import reverse
+from rest_framework.status import (
+    HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND)
+
+from parkings.models import PermitSeries
+
+url_list = reverse('operator:v1:permitseries-list')
+
+
+def test_operator_can_view_only_permitseries_owned_by_herself(
+    operator_api_client,
+    permit_series,
+    admin_user
+):
+    permit_series.owner = admin_user
+    permit_series.save()
+
+    response = operator_api_client.post(url_list, data={})
+    assert response.status_code == HTTP_201_CREATED
+
+    response = operator_api_client.get(url_list)
+
+    assert response.status_code == HTTP_200_OK
+    assert response.json()['count'] == 1
+    assert PermitSeries.objects.count() == 2
+    assert response.json()['results'][0]['id'] != permit_series.id
+
+
+def test_operator_can_delete_permitseries_owned_by_herself(
+    operator_api_client,
+    permit_series,
+    admin_user,
+    permit_series_factory
+):
+    admin_owned_permitseries = permit_series_factory(owner=admin_user)
+
+    url = reverse('operator:v1:permitseries-detail', kwargs={'pk': admin_owned_permitseries.pk})
+    response = operator_api_client.delete(url)
+
+    assert response.status_code == HTTP_404_NOT_FOUND
+    assert PermitSeries.objects.count() == 2
+
+    url = reverse('operator:v1:permitseries-detail', kwargs={'pk': permit_series.pk})
+    response = operator_api_client.delete(url)
+
+    assert response.status_code == HTTP_204_NO_CONTENT
+    assert PermitSeries.objects.count() == 1
+    assert PermitSeries.objects.first().id != permit_series.pk

--- a/parkings/tests/api/operator/test_permit_series.py
+++ b/parkings/tests/api/operator/test_permit_series.py
@@ -1,6 +1,8 @@
+import pytest
 from django.urls import reverse
 from rest_framework.status import (
-    HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND)
+    HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT, HTTP_400_BAD_REQUEST,
+    HTTP_404_NOT_FOUND)
 
 from parkings.models import PermitSeries
 
@@ -46,3 +48,85 @@ def test_operator_can_delete_permitseries_owned_by_herself(
     assert response.status_code == HTTP_204_NO_CONTENT
     assert PermitSeries.objects.count() == 1
     assert PermitSeries.objects.first().id != permit_series.pk
+
+
+def get_activate_url(obj):
+    return reverse('operator:v1:permitseries-detail', kwargs={'pk': obj.pk})
+
+
+def _create_permit_series(count=3, owner=None, active=False):
+    for _ in range(count):
+        PermitSeries.objects.create(active=active, owner=owner)
+
+
+@pytest.mark.parametrize('deactivate_others', [True, False])
+def test_operator_can_deactivate_all_other_series_activating_main(
+    operator_api_client, operator, deactivate_others
+):
+    _create_permit_series(count=5, owner=operator.user, active=True)
+    assert PermitSeries.objects.count() == 5
+
+    series_to_activate = PermitSeries.objects.first()
+    series_to_activate.active = False
+    series_to_activate.save()
+
+    response = operator_api_client.post(
+        '{}activate/'.format(get_activate_url(series_to_activate)),
+        data={'deactivate_others': deactivate_others},
+    )
+
+    assert response.status_code == HTTP_200_OK
+    series_to_activate.refresh_from_db()
+    assert series_to_activate.active
+    assert response.json()['status'] == 'OK'
+
+    if deactivate_others:
+        assert PermitSeries.objects.filter(active=True).count() == 1
+    else:
+        assert PermitSeries.objects.filter(active=True).count() == 5
+
+
+def test_operator_can_deactivate_specified_series_activating_main(
+    operator_api_client, operator
+):
+    _create_permit_series(count=5, owner=operator.user, active=True)
+    assert PermitSeries.objects.count() == 5
+
+    series_to_activate = PermitSeries.objects.first()
+    series_to_activate.active = False
+    series_to_activate.save()
+
+    series_to_deactivate = list(
+        PermitSeries.objects.values_list('id', flat=True)[3:]
+    )
+
+    response = operator_api_client.post(
+        '{}activate/'.format(get_activate_url(series_to_activate)),
+        data={'deactivate_series': series_to_deactivate},
+    )
+
+    assert response.status_code == HTTP_200_OK
+    series_to_activate.refresh_from_db()
+    assert series_to_activate.active
+    assert response.json()['status'] == 'OK'
+    assert PermitSeries.objects.filter(active=False).count() == 2
+    assert PermitSeries.objects.filter(active=True).count() == 3
+
+    for series in PermitSeries.objects.filter(active=False):
+        assert series.id in series_to_deactivate
+
+
+def test_operator_activate_series_fails_when_required_post_data_is_missing(
+    operator_api_client, operator
+):
+    _create_permit_series(count=1, owner=operator.user, active=False)
+    series_to_activate = PermitSeries.objects.first()
+
+    response = operator_api_client.post(
+        '{}activate/'.format(get_activate_url(series_to_activate)),
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()['non_field_errors'] == [
+        'Either deactivate_others or deactivate_series is required'
+    ]

--- a/parkings/tests/conftest.py
+++ b/parkings/tests/conftest.py
@@ -3,9 +3,9 @@ from pytest_factoryboy import register
 
 from parkings.factories import (
     ActivePermitFactory, AdminUserFactory, DiscParkingFactory,
-    HistoryParkingFactory, OperatorFactory, ParkingAreaFactory, ParkingFactory,
-    PermitFactory, PermitSeriesFactory, RegionFactory, StaffUserFactory,
-    UserFactory)
+    EnforcementDomainFactory, EnforcerFactory, HistoryParkingFactory,
+    OperatorFactory, ParkingAreaFactory, ParkingFactory, PermitFactory,
+    PermitSeriesFactory, RegionFactory, StaffUserFactory, UserFactory)
 
 register(OperatorFactory)
 register(ParkingFactory, 'parking')
@@ -19,6 +19,8 @@ register(PermitFactory, 'permit')
 register(PermitSeriesFactory, 'permit_series')
 register(ActivePermitFactory, 'active_permit')
 register(DiscParkingFactory, 'disc_parking')
+register(EnforcementDomainFactory, 'enforcement_domain')
+register(EnforcerFactory)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
This PR adds following stuffs:
* Refactoring of code so that the common endpoints could be shared between enforcement and operator endpoints
* Add current operator as owner of permitseries while creating permitseries
* Add endpoint to list enforcement domain to Operator API
* Add endpoint to CRUD permit to Operator API
* Add endpoint to activate/deactivate permitseries to Operator API
* Add endpoint to CRUD permitseries to Operator API
* Add domain field to parkings.