### PR TITLE
Operator permit endpoints

### DIFF
--- a/parkings/api/common_permit.py
+++ b/parkings/api/common_permit.py
@@ -6,8 +6,7 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 
-from ...models import EnforcementDomain, Permit, PermitSeries
-from .permissions import IsEnforcer
+from ..models import EnforcementDomain, Permit, PermitSeries
 
 
 class PermitSeriesSerializer(serializers.ModelSerializer):
@@ -26,7 +25,6 @@ class CreateAndReadOnlyModelViewSet(
 
 
 class PermitSeriesViewSet(CreateAndReadOnlyModelViewSet):
-    permission_classes = [IsEnforcer]
     queryset = PermitSeries.objects.all()
     serializer_class = PermitSeriesSerializer
 
@@ -94,7 +92,6 @@ class PermitSerializer(serializers.ModelSerializer):
 
 
 class PermitViewSet(viewsets.ModelViewSet):
-    permission_classes = [IsEnforcer]
     queryset = Permit.objects.all()
     serializer_class = PermitSerializer
     filter_backends = [DjangoFilterBackend]
@@ -115,7 +112,6 @@ class ActivePermitByExternalIdSerializer(PermitSerializer):
 
 
 class ActivePermitByExternalIdViewSet(viewsets.ModelViewSet):
-    permission_classes = [IsEnforcer]
     queryset = Permit.objects.active().exclude(external_id=None)
     serializer_class = ActivePermitByExternalIdSerializer
     lookup_field = 'external_id'

--- a/parkings/api/enforcement/enforcement_permit.py
+++ b/parkings/api/enforcement/enforcement_permit.py
@@ -1,0 +1,15 @@
+from ..common_permit import (
+    ActivePermitByExternalIdViewSet, PermitSeriesViewSet, PermitViewSet)
+from .permissions import IsEnforcer
+
+
+class EnforcementPermitSeriesViewSet(PermitSeriesViewSet):
+    permission_classes = [IsEnforcer]
+
+
+class EnforcementPermitViewSet(PermitViewSet):
+    permission_classes = [IsEnforcer]
+
+
+class EnforcementActivePermitByExternalIdViewSet(ActivePermitByExternalIdViewSet):
+    permission_classes = [IsEnforcer]

--- a/parkings/api/enforcement/urls.py
+++ b/parkings/api/enforcement/urls.py
@@ -3,9 +3,10 @@ from rest_framework.routers import DefaultRouter
 
 from ..url_utils import versioned_url
 from .check_parking import CheckParking
+from .enforcement_permit import (
+    EnforcementActivePermitByExternalIdViewSet, EnforcementPermitSeriesViewSet,
+    EnforcementPermitViewSet)
 from .operator import OperatorViewSet
-from .permit import (
-    ActivePermitByExternalIdViewSet, PermitSeriesViewSet, PermitViewSet)
 from .valid_parking import ValidParkingViewSet
 
 
@@ -24,10 +25,10 @@ class Router(DefaultRouter):
 
 router = Router()
 router.register('operator', OperatorViewSet, basename='operator')
-router.register('permit', PermitViewSet, basename='permit')
+router.register('permit', EnforcementPermitViewSet, basename='permit')
 router.register('active_permit_by_external_id',
-                ActivePermitByExternalIdViewSet, basename='activepermit')
-router.register('permitseries', PermitSeriesViewSet, basename='permitseries')
+                EnforcementActivePermitByExternalIdViewSet, basename='activepermit')
+router.register('permitseries', EnforcementPermitSeriesViewSet, basename='permitseries')
 router.register('valid_parking', ValidParkingViewSet,
                 basename='valid_parking')
 

--- a/parkings/api/operator/parking.py
+++ b/parkings/api/operator/parking.py
@@ -2,11 +2,12 @@ import pytz
 from django.conf import settings
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
-from rest_framework import mixins, permissions, serializers, viewsets
+from rest_framework import mixins, serializers, viewsets
 
-from parkings.models import EnforcementDomain, Operator, Parking
+from parkings.models import EnforcementDomain, Parking
 
 from ..common import ParkingException
+from .permissions import IsOperator
 
 
 class OperatorAPIParkingSerializer(serializers.ModelSerializer):
@@ -82,24 +83,7 @@ class OperatorAPIParkingSerializer(serializers.ModelSerializer):
         return representation
 
 
-class OperatorAPIParkingPermission(permissions.BasePermission):
-    def has_permission(self, request, view):
-        """
-        Allow only operators to create/modify a parking.
-        """
-        user = request.user
-
-        if not user.is_authenticated:
-            return False
-
-        try:
-            user.operator
-            return True
-        except Operator.DoesNotExist:
-            pass
-
-        return False
-
+class OperatorAPIParkingPermission(IsOperator):
     def has_object_permission(self, request, view, obj):
         """
         Allow operators to modify only their own parkings.

--- a/parkings/api/operator/permissions.py
+++ b/parkings/api/operator/permissions.py
@@ -1,0 +1,22 @@
+from rest_framework import permissions
+
+from parkings.models import Operator
+
+
+class IsOperator(permissions.BasePermission):
+    def has_permission(self, request, view):
+        """
+        Allow only operators to proceed further.
+        """
+        user = request.user
+
+        if not user.is_authenticated:
+            return False
+
+        try:
+            user.operator
+            return True
+        except Operator.DoesNotExist:
+            pass
+
+        return False

--- a/parkings/api/operator/permit.py
+++ b/parkings/api/operator/permit.py
@@ -3,9 +3,10 @@ from rest_framework import mixins, serializers
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from parkings.models import Permit, PermitSeries
+from parkings.models import EnforcementDomain, Permit, PermitSeries
 
-from ..common_permit import PermitSeriesViewSet
+from ..common_permit import (
+    PermitSerializer, PermitSeriesViewSet, PermitViewSet)
 from .permissions import IsOperator
 
 
@@ -50,3 +51,16 @@ class PermitSeriesActivateBodySerializer(serializers.Serializer):
     deactivate_series = serializers.ListField(
         child=serializers.IntegerField(), required=False
     )
+
+
+class OperatorPermitSerializer(PermitSerializer):
+    domain = serializers.SlugRelatedField(
+        slug_field='code', queryset=EnforcementDomain.objects.all())
+
+    class Meta(PermitSerializer.Meta):
+        fields = PermitSerializer.Meta.fields + ['domain']
+
+
+class OperatorPermitViewSet(PermitViewSet):
+    serializer_class = OperatorPermitSerializer
+    permission_classes = [IsOperator]

--- a/parkings/api/operator/permit.py
+++ b/parkings/api/operator/permit.py
@@ -1,4 +1,9 @@
-from rest_framework import mixins
+from django.db import transaction
+from rest_framework import mixins, serializers
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from parkings.models import Permit, PermitSeries
 
 from ..common_permit import PermitSeriesViewSet
 from .permissions import IsOperator
@@ -6,3 +11,42 @@ from .permissions import IsOperator
 
 class OperatorPermitSeriesViewSet(mixins.DestroyModelMixin, PermitSeriesViewSet):
     permission_classes = [IsOperator]
+
+    @action(detail=True, methods=['post'])
+    def activate(self, request, pk=None):
+        activate_payload = PermitSeriesActivateBodySerializer(data=request.data)
+        activate_payload.is_valid(raise_exception=True)
+        validated_data = activate_payload.validated_data
+
+        with transaction.atomic():
+            obj_to_activate = self.get_object()
+            old_actives = self.get_queryset().filter(active=True)
+
+            if obj_to_activate.active and old_actives.count() == 1:
+                return Response({'status': 'No change'})
+
+            # Always activate the specified permit series regardless of what to deactivate
+            if not obj_to_activate.active:
+                obj_to_activate.active = True
+                obj_to_activate.save()
+
+            if validated_data['deactivate_others']:
+                old_actives.exclude(pk=obj_to_activate.pk).update(active=False)
+            else:
+                ids_to_deactivate = validated_data.get('deactivate_series', [])
+                old_actives.filter(id__in=ids_to_deactivate).exclude(
+                    pk=obj_to_activate.pk
+                ).update(active=False)
+
+            prunable_series = PermitSeries.objects.prunable()
+            Permit.objects.filter(series__in=prunable_series).delete()
+            prunable_series.delete()
+
+            return Response({'status': 'OK'})
+
+
+class PermitSeriesActivateBodySerializer(serializers.Serializer):
+    deactivate_others = serializers.BooleanField(required=False, default=False)
+    deactivate_series = serializers.ListField(
+        child=serializers.IntegerField(), required=False
+    )

--- a/parkings/api/operator/permit.py
+++ b/parkings/api/operator/permit.py
@@ -1,0 +1,8 @@
+from rest_framework import mixins
+
+from ..common_permit import PermitSeriesViewSet
+from .permissions import IsOperator
+
+
+class OperatorPermitSeriesViewSet(mixins.DestroyModelMixin, PermitSeriesViewSet):
+    permission_classes = [IsOperator]

--- a/parkings/api/operator/permit.py
+++ b/parkings/api/operator/permit.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from parkings.models import EnforcementDomain, Permit, PermitSeries
 
 from ..common_permit import (
+    ActivePermitByExternalIdSerializer, ActivePermitByExternalIdViewSet,
     PermitSerializer, PermitSeriesViewSet, PermitViewSet)
 from .permissions import IsOperator
 
@@ -64,3 +65,16 @@ class OperatorPermitSerializer(PermitSerializer):
 class OperatorPermitViewSet(PermitViewSet):
     serializer_class = OperatorPermitSerializer
     permission_classes = [IsOperator]
+
+
+class OperatorActivePermitByExtIdSerializer(ActivePermitByExternalIdSerializer):
+    domain = serializers.SlugRelatedField(
+        slug_field='code', queryset=EnforcementDomain.objects.all())
+
+    class Meta(ActivePermitByExternalIdSerializer.Meta):
+        fields = ActivePermitByExternalIdSerializer.Meta.fields + ['domain']
+
+
+class OperatorActivePermitByExternalIdViewSet(ActivePermitByExternalIdViewSet):
+    permission_classes = [IsOperator]
+    serializer_class = OperatorActivePermitByExtIdSerializer

--- a/parkings/api/operator/urls.py
+++ b/parkings/api/operator/urls.py
@@ -2,9 +2,11 @@ from rest_framework.routers import DefaultRouter
 
 from ..url_utils import versioned_url
 from .parking import OperatorAPIParkingViewSet
+from .permit import OperatorPermitSeriesViewSet
 
 router = DefaultRouter()
 router.register(r'parking', OperatorAPIParkingViewSet, basename='parking')
+router.register(r'permitseries', OperatorPermitSeriesViewSet, basename='permitseries')
 
 app_name = 'operator'
 urlpatterns = [

--- a/parkings/api/operator/urls.py
+++ b/parkings/api/operator/urls.py
@@ -2,11 +2,12 @@ from rest_framework.routers import DefaultRouter
 
 from ..url_utils import versioned_url
 from .parking import OperatorAPIParkingViewSet
-from .permit import OperatorPermitSeriesViewSet
+from .permit import OperatorPermitSeriesViewSet, OperatorPermitViewSet
 
 router = DefaultRouter()
 router.register(r'parking', OperatorAPIParkingViewSet, basename='parking')
 router.register(r'permitseries', OperatorPermitSeriesViewSet, basename='permitseries')
+router.register(r'permit', OperatorPermitViewSet, basename='permit')
 
 app_name = 'operator'
 urlpatterns = [

--- a/parkings/api/operator/urls.py
+++ b/parkings/api/operator/urls.py
@@ -2,12 +2,15 @@ from rest_framework.routers import DefaultRouter
 
 from ..url_utils import versioned_url
 from .parking import OperatorAPIParkingViewSet
-from .permit import OperatorPermitSeriesViewSet, OperatorPermitViewSet
+from .permit import (
+    OperatorActivePermitByExternalIdViewSet, OperatorPermitSeriesViewSet,
+    OperatorPermitViewSet)
 
 router = DefaultRouter()
 router.register(r'parking', OperatorAPIParkingViewSet, basename='parking')
 router.register(r'permitseries', OperatorPermitSeriesViewSet, basename='permitseries')
 router.register(r'permit', OperatorPermitViewSet, basename='permit')
+router.register(r'activepermit', OperatorActivePermitByExternalIdViewSet, basename='activepermit')
 
 app_name = 'operator'
 urlpatterns = [

--- a/parkings/tests/api/operator/test_active_permit_by_external_id.py
+++ b/parkings/tests/api/operator/test_active_permit_by_external_id.py
@@ -1,0 +1,90 @@
+from django.urls import reverse
+from rest_framework.status import (
+    HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND)
+
+from parkings.models import EnforcementDomain, Permit
+
+from ....factories.permit import (
+    generate_areas, generate_external_ids, generate_subjects)
+
+list_url = reverse('operator:v1:activepermit-list')
+
+
+def check_response_keys(response_data):
+    expected_keys = {
+        'id', 'domain', 'external_id',
+        'series', 'subjects', 'areas'
+    }
+
+    assert expected_keys == set(response_data.keys())
+
+
+def test_operator_can_post_active_permit_by_external_id(operator_api_client, active_permit):
+    enforcement_domain = EnforcementDomain.objects.create(code='ESP', name='EspooDomain')
+    data = {
+        'external_id': generate_external_ids(),
+        'subjects': generate_subjects(),
+        'areas': generate_areas(),
+        'domain': enforcement_domain.code,
+    }
+
+    response = operator_api_client.post(list_url, data=data)
+
+    assert response.status_code == HTTP_201_CREATED
+    assert response.json()['series'] == active_permit.series.id
+    check_response_keys(response.json())
+
+
+def test_operator_cannot_view_permit_in_active_series_owned_by_other_operator(
+    operator_api_client, active_permit, permit
+):
+    response = operator_api_client.get(list_url)
+
+    assert response.status_code == HTTP_200_OK
+    assert response.data['count'] == 0
+    assert Permit.objects.count() == 2
+
+
+def test_operator_can_only_view_permit_in_active_series_owned_by_themselves(
+    operator_api_client, active_permit, operator,
+    permit_series_factory, permit_factory, permit
+):
+    operator_owned_active_permitseries = permit_series_factory(active=True, owner=operator.user)
+    operator_permit = permit_factory(series=operator_owned_active_permitseries)
+
+    response = operator_api_client.get(list_url)
+
+    assert response.status_code == HTTP_200_OK
+    assert response.data['count'] == 1
+    assert Permit.objects.count() == 3
+    assert response.json()['results'][0]['id'] == operator_permit.id
+    assert response.json()['results'][0]['series'] == operator_owned_active_permitseries.id
+
+
+def get_active_permit_by_ext_id_detail_url(active_permit):
+    return reverse(
+        'operator:v1:activepermit-detail',
+        kwargs={'external_id': active_permit.external_id}
+    )
+
+
+def test_operator_can_only_delete_permit_in_active_series_owned_by_themselves(
+    operator_api_client, active_permit, permit, operator,
+    permit_series_factory, permit_factory
+):
+    url = get_active_permit_by_ext_id_detail_url(active_permit)
+
+    response = operator_api_client.delete(url)
+
+    assert response.status_code == HTTP_404_NOT_FOUND
+    assert Permit.objects.count() == 2
+
+    operator_owned_active_permitseries = permit_series_factory(active=True, owner=operator.user)
+    operator_permit = permit_factory(series=operator_owned_active_permitseries)
+
+    url = get_active_permit_by_ext_id_detail_url(operator_permit)
+
+    response = operator_api_client.delete(url)
+
+    assert response.status_code == HTTP_204_NO_CONTENT
+    assert not Permit.objects.filter(id=operator_permit.id).exists()

--- a/parkings/tests/api/operator/test_permit.py
+++ b/parkings/tests/api/operator/test_permit.py
@@ -1,0 +1,212 @@
+from django.urls import reverse
+from rest_framework.status import (
+    HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND)
+
+from parkings.models import EnforcementDomain, Enforcer, Permit
+
+from ....factories.permit import (
+    generate_areas, generate_external_ids, generate_subjects)
+
+list_url = reverse('operator:v1:permit-list')
+
+
+def _get_detail_url(obj):
+    return reverse('operator:v1:permit-detail', kwargs={'pk': obj.pk})
+
+
+def _get_permit_data(permit_series):
+    return {
+        'series': permit_series.id,
+        'external_id': generate_external_ids(),
+        'subjects': generate_subjects(),
+        'areas': generate_areas(),
+    }
+
+
+def _check_response(data, obj):
+    permit_response_keys = {
+        'series',
+        'domain',
+        'external_id',
+        'id',
+        'subjects',
+        'areas',
+    }
+
+    assert set(data.keys()) == permit_response_keys
+    assert obj.series.pk == data['series']
+    assert obj.domain.code == data['domain']
+    assert obj.external_id == data['external_id']
+    assert obj.id == data['id']
+    assert obj.subjects == data['subjects']
+    assert obj.areas == data['areas']
+
+
+def _create_enforcement_domain_and_enforcer(user, code='ESP'):
+    domain = EnforcementDomain.objects.create(code=code, name='EspooDomain')
+    enforcer = Enforcer.objects.create(user=user, enforced_domain=domain)
+
+    return (domain, enforcer)
+
+
+def test_operator_can_create_permit_with_valid_post_data(
+    operator_api_client, permit_series, operator
+):
+    domain, _ = _create_enforcement_domain_and_enforcer(operator.user)
+    permit_data = _get_permit_data(permit_series)
+    permit_data.update(domain=domain.code)
+
+    response = operator_api_client.post(list_url, data=permit_data)
+
+    assert response.status_code == HTTP_201_CREATED
+    _check_response(response.json(), Permit.objects.first())
+
+
+def test_operator_cannot_view_permit_owned_by_other_operator(
+    operator_api_client, operator_2_api_client, operator,
+    operator_2, permit_series_factory, permit_factory,
+):
+    operator1_owned_permitseries = permit_series_factory(owner=operator.user)
+    operator2_owned_permitseries = permit_series_factory(owner=operator_2.user)
+
+    operator1_permit_list = [permit_factory(series=operator1_owned_permitseries) for _ in range(3)]
+    operator2_permit_list = [permit_factory(series=operator2_owned_permitseries) for _ in range(3)]
+
+    response = operator_api_client.get(list_url)
+    json_response = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    assert json_response['count'] == 3
+    assert Permit.objects.count() == 6
+    assert set([permit['id'] for permit in json_response['results']]) == set(
+        [permit.id for permit in operator1_permit_list]
+    )
+
+    operator_permit_response_obj = [
+        permit
+        for permit in json_response['results']
+        if permit['id'] == operator1_permit_list[0].id
+    ][0]
+    _check_response(operator_permit_response_obj, operator1_permit_list[0])
+
+    response = operator_2_api_client.get(list_url)
+    json_response = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    assert json_response['count'] == 3
+    assert set([permit['id'] for permit in json_response['results']]) == set(
+        [permit.id for permit in operator2_permit_list]
+    )
+
+    operator2_permit_response_obj = [
+        permit
+        for permit in json_response['results']
+        if permit['id'] == operator2_permit_list[0].id
+    ][0]
+    _check_response(operator2_permit_response_obj, operator2_permit_list[0])
+
+
+def test_operator_cannot_modify_permit_owned_by_other_operator(
+    operator_api_client, operator, operator_2,
+    permit_series_factory, permit_factory
+):
+    operator1_owned_permitseries = permit_series_factory(owner=operator.user)
+    operator2_owned_permitseries = permit_series_factory(owner=operator_2.user)
+
+    operator1_permit_list = [permit_factory(series=operator1_owned_permitseries) for _ in range(3)]
+    operator2_permit_list = [permit_factory(series=operator2_owned_permitseries) for _ in range(3)]
+
+    operator1_permit = operator1_permit_list[0]
+    operator2_permit = operator2_permit_list[0]
+    patch_data = {'external_id': 'ABC123'}
+
+    response = operator_api_client.patch(
+        _get_detail_url(operator2_permit), data=patch_data
+    )
+
+    assert response.status_code == HTTP_404_NOT_FOUND
+
+    response = operator_api_client.patch(
+        _get_detail_url(operator1_permit), data=patch_data
+    )
+
+    assert response.status_code == HTTP_200_OK
+    assert response.json()['external_id'] == 'ABC123'
+
+
+def test_operator_cannot_delete_permit_owned_by_other_operator(
+    operator_api_client, operator, operator_2,
+    permit_series_factory, permit_factory
+):
+    operator1_owned_permitseries = permit_series_factory(owner=operator.user)
+    operator2_owned_permitseries = permit_series_factory(owner=operator_2.user)
+
+    operator1_permit_list = [permit_factory(series=operator1_owned_permitseries) for _ in range(3)]
+    operator2_permit_list = [permit_factory(series=operator2_owned_permitseries) for _ in range(3)]
+
+    operator1_permit = operator1_permit_list[0]
+    operator2_permit = operator2_permit_list[0]
+
+    response = operator_api_client.delete(
+        _get_detail_url(operator2_permit)
+    )
+
+    assert response.status_code == HTTP_404_NOT_FOUND
+    assert Permit.objects.count() == 6
+
+    response = operator_api_client.delete(
+        _get_detail_url(operator1_permit)
+    )
+
+    assert response.status_code == HTTP_204_NO_CONTENT
+    assert Permit.objects.count() == 5
+    assert not Permit.objects.filter(id=operator1_permit.id).exists()
+
+
+def test_operator_and_enforcers_cannot_see_each_others_permit(
+    operator_api_client, permit_series_factory, operator, staff_api_client,
+    staff_user, permit_factory
+):
+    reg_number = 'ABC-123'
+    permit_subject = generate_subjects()
+    permit_subject[0].update(registration_number=reg_number)
+
+    enforcer_domain = EnforcementDomain.objects.create(code='HEL', name='HelDomain')
+    enforcer_permitseries = permit_series_factory(owner=staff_user)
+    enforcer_permit_list = [
+        permit_factory(subjects=permit_subject, series=enforcer_permitseries, domain=enforcer_domain)
+        for _
+        in range(3)
+    ]
+    Enforcer.objects.create(user=staff_user, enforced_domain=enforcer_domain)
+
+    operator_domain = EnforcementDomain.objects.create(code='ESP', name='EspooDomain')
+    operator_permitseries = permit_series_factory(owner=operator.user)
+    operator_permit_domain = [operator_domain, enforcer_domain]
+    operator_permit_list = [
+        permit_factory(subjects=permit_subject, domain=domain, series=operator_permitseries)
+        for domain
+        in operator_permit_domain
+        ]
+
+    #  Operator should see only operator_permit_list
+    response = operator_api_client.get(list_url)
+    json_response = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    assert json_response['count'] == 2
+    assert set([permit['id'] for permit in json_response['results']]) == set(
+        [permit.id for permit in operator_permit_list]
+    )
+
+    enforcement_permit_url = reverse('enforcement:v1:permit-list')
+
+    #  Enforcer should see only enforcer_permit_list
+    response = staff_api_client.get(enforcement_permit_url)
+    json_response = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    assert json_response['count'] == 3
+    assert set([permit['id'] for permit in json_response['results']]) == set(
+        [permit.id for permit in enforcer_permit_list]
+    )

--- a/parkings/tests/api/operator/test_permit_series.py
+++ b/parkings/tests/api/operator/test_permit_series.py
@@ -1,3 +1,4 @@
+import pytest
 from django.urls import reverse
 from rest_framework.status import (
     HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND)
@@ -46,3 +47,142 @@ def test_operator_can_delete_permitseries_owned_by_herself(
     assert response.status_code == HTTP_204_NO_CONTENT
     assert PermitSeries.objects.count() == 1
     assert PermitSeries.objects.first().id != permit_series.pk
+
+
+def get_permitseries_detail_url(obj):
+    return reverse('operator:v1:permitseries-detail', kwargs={'pk': obj.pk})
+
+
+def _create_permit_series(count=3, owner=None, active=False):
+    for _ in range(count):
+        PermitSeries.objects.create(active=active, owner=owner)
+
+
+@pytest.mark.parametrize('deactivate_others', [True, False])
+def test_operator_can_deactivate_all_other_series_activating_main(
+    operator_api_client, operator, deactivate_others
+):
+    _create_permit_series(count=5, owner=operator.user, active=True)
+    assert PermitSeries.objects.count() == 5
+
+    series_to_activate = PermitSeries.objects.first()
+    series_to_activate.active = False
+    series_to_activate.save()
+
+    response = operator_api_client.post(
+        '{}activate/'.format(get_permitseries_detail_url(series_to_activate)),
+        data={'deactivate_others': deactivate_others},
+    )
+
+    assert response.status_code == HTTP_200_OK
+    series_to_activate.refresh_from_db()
+    assert series_to_activate.active
+    assert response.json()['status'] == 'OK'
+
+    if deactivate_others:
+        assert PermitSeries.objects.filter(active=True).count() == 1
+    else:
+        assert PermitSeries.objects.filter(active=True).count() == 5
+
+
+def test_operator_can_deactivate_specified_series_activating_main(
+    operator_api_client, operator
+):
+    _create_permit_series(count=5, owner=operator.user, active=True)
+    assert PermitSeries.objects.count() == 5
+
+    series_to_activate = PermitSeries.objects.first()
+    series_to_activate.active = False
+    series_to_activate.save()
+
+    series_to_deactivate = list(
+        PermitSeries.objects.values_list('id', flat=True)[3:]
+    )
+
+    response = operator_api_client.post(
+        '{}activate/'.format(get_permitseries_detail_url(series_to_activate)),
+        data={'deactivate_series': series_to_deactivate},
+    )
+
+    assert response.status_code == HTTP_200_OK
+    series_to_activate.refresh_from_db()
+    assert series_to_activate.active
+    assert response.json()['status'] == 'OK'
+    assert PermitSeries.objects.filter(active=False).count() == 2
+    assert PermitSeries.objects.filter(active=True).count() == 3
+
+    for series in PermitSeries.objects.filter(active=False):
+        assert series.id in series_to_deactivate
+
+
+def test_operator_activates_specified_series_and_deactivates_no_other_series_on_empty_payload(
+    operator_api_client, operator
+):
+    _create_permit_series(count=3, owner=operator.user, active=True)
+    series_to_activate = PermitSeries.objects.create(owner=operator.user, active=False)
+
+    response = operator_api_client.post(
+        '{}activate/'.format(get_permitseries_detail_url(series_to_activate), data={}),
+    )
+
+    assert response.status_code == HTTP_200_OK
+    series_to_activate.refresh_from_db()
+
+    assert series_to_activate.active
+    assert PermitSeries.objects.filter(active=False).count() == 0
+
+
+def test_operator_activate_series_doesnot_deactivate_enforcer_owned_series(
+    operator_api_client, operator, staff_user
+):
+    _create_permit_series(count=5, owner=operator.user, active=True)
+    _create_permit_series(count=5, owner=staff_user, active=True)
+
+    series_to_activate = PermitSeries.objects.filter(owner=operator.user).first()
+    series_to_activate.active = False
+    series_to_activate.save()
+
+    response = operator_api_client.post(
+        '{}activate/'.format(get_permitseries_detail_url(series_to_activate)),
+        data={'deactivate_others': True},
+    )
+
+    assert response.status_code == HTTP_200_OK
+    series_to_activate.refresh_from_db()
+    assert series_to_activate.active
+    assert response.json()['status'] == 'OK'
+    assert not PermitSeries.objects.filter(owner=staff_user, active=False).exists()
+
+
+def test_operator_cannot_deactivate_series_owned_by_others_even_when_explicitly_specified(
+    operator_api_client, operator, staff_user
+):
+    _create_permit_series(count=5, owner=operator.user, active=True)
+    _create_permit_series(count=5, owner=staff_user, active=True)
+
+    series_to_activate = PermitSeries.objects.first()
+    series_to_activate.active = False
+    series_to_activate.save()
+
+    staff_series_to_deactivate = list(
+        PermitSeries.objects.filter(owner=staff_user).values_list('id', flat=True)[3:]
+    )
+    operator_series_to_deactivate = list(
+        PermitSeries.objects.filter(owner=operator.user).values_list('id', flat=True)[3:]
+    )
+    series_to_deactivate = staff_series_to_deactivate + operator_series_to_deactivate
+
+    response = operator_api_client.post(
+        '{}activate/'.format(get_permitseries_detail_url(series_to_activate)),
+        data={'deactivate_series': series_to_deactivate},
+    )
+
+    assert response.status_code == HTTP_200_OK
+    series_to_activate.refresh_from_db()
+    assert series_to_activate.active
+    assert response.json()['status'] == 'OK'
+    assert PermitSeries.objects.filter(active=False).count() == 2
+    assert PermitSeries.objects.filter(active=True).count() == 8
+
+    for series in PermitSeries.objects.filter(active=False):
+        assert series.id in operator_series_to_deactivate

--- a/parkings/tests/api/operator/test_permit_series.py
+++ b/parkings/tests/api/operator/test_permit_series.py
@@ -1,0 +1,48 @@
+from django.urls import reverse
+from rest_framework.status import (
+    HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND)
+
+from parkings.models import PermitSeries
+
+url_list = reverse('operator:v1:permitseries-list')
+
+
+def test_operator_can_view_only_permitseries_owned_by_herself(
+    operator_api_client,
+    permit_series,
+    admin_user
+):
+    permit_series.owner = admin_user
+    permit_series.save()
+
+    response = operator_api_client.post(url_list, data={})
+    assert response.status_code == HTTP_201_CREATED
+
+    response = operator_api_client.get(url_list)
+
+    assert response.status_code == HTTP_200_OK
+    assert response.json()['count'] == 1
+    assert PermitSeries.objects.count() == 2
+    assert response.json()['results'][0]['id'] != permit_series.id
+
+
+def test_operator_can_delete_permitseries_owned_by_herself(
+    operator_api_client,
+    permit_series,
+    admin_user,
+    permit_series_factory
+):
+    admin_owned_permitseries = permit_series_factory(owner=admin_user)
+
+    url = reverse('operator:v1:permitseries-detail', kwargs={'pk': admin_owned_permitseries.pk})
+    response = operator_api_client.delete(url)
+
+    assert response.status_code == HTTP_404_NOT_FOUND
+    assert PermitSeries.objects.count() == 2
+
+    url = reverse('operator:v1:permitseries-detail', kwargs={'pk': permit_series.pk})
+    response = operator_api_client.delete(url)
+
+    assert response.status_code == HTTP_204_NO_CONTENT
+    assert PermitSeries.objects.count() == 1
+    assert PermitSeries.objects.first().id != permit_series.pk


### PR DESCRIPTION
This PR adds following stuffs:
* Refactor Enforcement API permit endpoints to be reusable in Operator API
* Split the IsOperator permission to make it reusable
* Add permitseries endpoint 
* Add endpoint to activate permitseries
* Add permit endpoint
* Add activepermit endpoint