### PR TITLE
Permit creation restriction based on permit area

### DIFF
--- a/parkings/api/operator/urls.py
+++ b/parkings/api/operator/urls.py
@@ -4,13 +4,14 @@ from ..url_utils import versioned_url
 from .parking import OperatorAPIParkingViewSet
 from .permit import (
     OperatorActivePermitByExternalIdViewSet, OperatorPermitSeriesViewSet,
-    OperatorPermitViewSet)
+    OperatorPermittedPermitAreaViewSet, OperatorPermitViewSet)
 
 router = DefaultRouter()
 router.register(r'parking', OperatorAPIParkingViewSet, basename='parking')
 router.register(r'permitseries', OperatorPermitSeriesViewSet, basename='permitseries')
 router.register(r'permit', OperatorPermitViewSet, basename='permit')
 router.register(r'activepermit', OperatorActivePermitByExternalIdViewSet, basename='activepermit')
+router.register(r'permit_area', OperatorPermittedPermitAreaViewSet, basename='permitarea')
 
 app_name = 'operator'
 urlpatterns = [

--- a/parkings/tests/api/operator/permit_area.py
+++ b/parkings/tests/api/operator/permit_area.py
@@ -1,0 +1,55 @@
+from django.urls import reverse
+from rest_framework.status import HTTP_200_OK
+
+from parkings.models import EnforcementDomain, PermitArea
+
+from ..enforcement.test_check_parking import create_area_geom
+
+list_url = reverse('operator:v1:permitarea-list')
+
+
+def test_endpoint_returns_list_of_permitareas(operator_api_client, operator):
+    domain = EnforcementDomain.objects.create(code='ESP', name='Espoo')
+    PermitArea.objects.create(
+        name='AreaOne', geom=create_area_geom(),
+        identifier='A',
+        permitted_user=operator.user,
+        domain=domain
+    )
+
+    response = operator_api_client.get(list_url)
+    json_response = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    expected_keys = {'code', 'domain', 'name'}
+    assert json_response['count'] == 1
+    assert set(json_response['results'][0]) == expected_keys
+    assert json_response['results'][0]['domain'] == domain.code
+    assert json_response['results'][0]['code'] == 'A'
+    assert json_response['results'][0]['name'] == 'AreaOne'
+
+
+def test_endpoint_returns_only_the_list_of_permitted_permitareas(
+    operator_api_client, operator, staff_user
+):
+    domain = EnforcementDomain.objects.create(code='ESP', name='Espoo')
+    PermitArea.objects.create(
+        name='AreaOne', geom=create_area_geom(),
+        identifier='A',
+        permitted_user=operator.user,
+        domain=domain
+    )
+    PermitArea.objects.create(
+        name='AreaTwo', geom=create_area_geom(),
+        identifier='B',
+        permitted_user=staff_user,
+        domain=domain
+    )
+
+    response = operator_api_client.get(list_url)
+    json_response = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    assert json_response['count'] == 1
+    assert json_response['results'][0]['code'] == 'A'
+    assert PermitArea.objects.count() == 2

--- a/parkings/tests/api/operator/test_permit.py
+++ b/parkings/tests/api/operator/test_permit.py
@@ -2,10 +2,11 @@ from django.urls import reverse
 from rest_framework.status import (
     HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND)
 
-from parkings.models import EnforcementDomain, Enforcer, Permit
+from parkings.models import EnforcementDomain, Enforcer, Permit, PermitArea
 
 from ....factories.permit import (
     generate_areas, generate_external_ids, generate_subjects)
+from ..enforcement.test_check_parking import create_area_geom
 
 list_url = reverse('operator:v1:permit-list')
 
@@ -219,3 +220,68 @@ def test_operator_and_enforcers_cannot_see_each_others_permit(
     assert set([permit['id'] for permit in json_response['results']]) == set(
         [permit.id for permit in enforcer_permit_list]
     )
+
+
+def test_operator_can_only_create_permit_on_permitareas_where_she_is_permitted(
+    operator_api_client, permit_series_factory, operator
+):
+    area = generate_areas()
+    area_identifier = area[0]['area']
+
+    permit_series = permit_series_factory(active=True)
+    operator_domain = EnforcementDomain.objects.create(code='ESP', name='EspooDomain')
+
+    permit_data = {
+        'series': permit_series.id,
+        'external_id': generate_external_ids(),
+        'subjects': generate_subjects(),
+        'areas': area,
+        'domain': operator_domain.code
+    }
+
+    PermitArea.objects.create(
+        name='Kamppi',
+        identifier=area_identifier,
+        geom=create_area_geom(),
+        permitted_user=operator.user,
+        domain=operator_domain
+    )
+
+    response = operator_api_client.post(list_url, data=permit_data)
+    json_response = response.json()
+
+    assert response.status_code == HTTP_201_CREATED
+    assert json_response['domain'] == operator_domain.code
+    assert json_response['series'] == permit_series.id
+
+
+def test_operator_cannot_create_permit_on_permitareas_where_she_is_not_permitted(
+    operator_api_client, permit_series_factory, operator, staff_user
+):
+    area = generate_areas()
+    area_identifier = area[0]['area']
+
+    permit_series = permit_series_factory(active=True)
+    operator_domain = EnforcementDomain.objects.create(code='ESP', name='EspooDomain')
+
+    permit_data = {
+        'series': permit_series.id,
+        'external_id': generate_external_ids(),
+        'subjects': generate_subjects(),
+        'areas': area,
+        'domain': operator_domain.code
+    }
+
+    PermitArea.objects.create(
+        name='Kamppi',
+        identifier=area_identifier,
+        geom=create_area_geom(),
+        permitted_user=staff_user,
+        domain=operator_domain
+    )
+
+    response = operator_api_client.post(list_url, data=permit_data)
+
+    assert response.json()['non_field_errors'] == [
+        'You are not permitted to create permit in this area'
+    ]


### PR DESCRIPTION
This PR is based on `operator_permit_endpoints` branch and adds following items:
* Add restriction to operator permit area usage.
* Add permit area endpoint to list the permitted permit areas.