### PR TITLE
Add parking forecast model training and predictions

### DIFF
--- a/parkings/cron.py
+++ b/parkings/cron.py
@@ -1,0 +1,29 @@
+from django.conf import settings
+from django_cron import CronJobBase, Schedule
+
+from parkings.forecasts.cache_parking_counts import (
+    cache_parking_counts_by_region)
+from parkings.forecasts.forecast_parking_counts import (
+    forecast_region_parking_counts)
+
+
+class CacheRegionParkingCountsCronJob(CronJobBase):
+    RUN_AT_TIMES = ["0:00"]
+
+    schedule = Schedule(run_at_times=RUN_AT_TIMES)
+    code = "parkings.CacheRegionParkingCountsCronJob"
+
+    def do(self):
+        if settings.ENABLE_FORECAST_CRON_JOB:
+            cache_parking_counts_by_region()
+
+
+class ForecastRegionParkingsCronJob(CronJobBase):
+    RUN_AT_TIMES = ["3:00"]
+
+    schedule = Schedule(run_at_times=RUN_AT_TIMES)
+    code = "parkings.ForecastRegionParkingsCronJob"
+
+    def do(self):
+        if settings.ENABLE_FORECAST_CRON_JOB:
+            forecast_region_parking_counts()

--- a/parkings/forecasts/forecast_parking_counts.py
+++ b/parkings/forecasts/forecast_parking_counts.py
@@ -1,0 +1,102 @@
+import datetime
+
+from catboost import CatBoostRegressor
+from django.conf import settings
+
+from parkings.forecasts.utils import (
+    add_time_data_to_df, get_parking_area_parking_df, get_region_parking_df)
+from parkings.models import ParkingArea, ParkingCount, Region
+
+ITERATIONS = 200  # Optimized with grid search
+LEARNING_RATE = 0.06  # Optimized with grid search
+DEPTH = 8  # Optimized with grid search
+
+
+def train_model(parking_df):
+    """
+    Train CatBoost model with parameters that were optimized in Google cloud with
+    grid search.
+
+    :param parking_df: Input dataset for the predictions.
+    :type parking_df: pandas.DataFrame
+    :return: The predicted signal name and the predictions as a vector.
+    :rtype: str, numpy.ndarray
+    """
+
+    # Create separate CatBoost models for each column.
+    for signal_name in parking_df.columns:
+        training_parking_df = parking_df[[signal_name]]
+
+        # Add input dataset for training data.
+        shifted_df = training_parking_df.shift(settings.FORECAST_PERIOD)
+        training_parking_df["shift_week_ago"] = shifted_df[[signal_name]]
+        training_parking_df = training_parking_df.dropna()
+        training_parking_df = add_time_data_to_df(training_parking_df)
+
+        # Create prediction input dataset.
+        prediction_df = shifted_df.tail(settings.FORECAST_PERIOD)
+        prediction_df = prediction_df.rename(columns={signal_name: "shift_week_ago"})
+        prediction_df = add_time_data_to_df(prediction_df)
+
+        # Input signals.
+        x_data = training_parking_df.drop(columns=[signal_name])
+        # Expected output signal.
+        y_data = training_parking_df[signal_name]
+
+        model = CatBoostRegressor(
+            iterations=ITERATIONS, learning_rate=LEARNING_RATE, depth=DEPTH
+        )
+
+        model.fit(x_data, y_data, verbose=False)
+
+        predictions = model.predict(prediction_df)
+
+        yield signal_name, predictions
+
+
+def forecast_region_parking_counts():
+    """
+    Train model for Regions and get the predictions to save in the database.
+    """
+    parking_df = get_region_parking_df()
+    # Datetime of the final entry in the input dataset.
+    final_datetime = parking_df.index[-1].to_pydatetime()
+
+    for signal_name, region_predictions in train_model(parking_df):
+        region = Region.objects.get(name=signal_name)
+        ParkingCount.objects.bulk_create(
+            (
+                ParkingCount(
+                    is_forecast=True,
+                    number=int(park_count),
+                    region=region,
+                    time=final_datetime + datetime.timedelta(hours=idx + 1),
+                )
+                for idx, park_count in enumerate(region_predictions)
+            ),
+            ignore_conflicts=True,
+        )
+
+
+def forecast_parking_area_parking_counts():
+    """
+    Train model for ParkingAreas and get the predictions to save in the database.
+    """
+    parking_df = get_parking_area_parking_df()
+    # Datetime of the final entry in the input dataset.
+    final_datetime = parking_df.index[-1].to_pydatetime()
+
+    for signal_name, parking_area_predictions in train_model(parking_df):
+        parking_area = ParkingArea.objects.get(origin_id=signal_name)
+        ParkingCount.objects.bulk_create(
+            (
+                ParkingCount(
+                    is_forecast=True,
+                    number=int(park_count),
+                    parking_area=parking_area,
+                    time=final_datetime + datetime.timedelta(hours=idx + 1),
+                )
+                for idx, park_count in enumerate(parking_area_predictions)
+            ),
+            ignore_conflicts=True,
+        )

--- a/parkings/forecasts/utils.py
+++ b/parkings/forecasts/utils.py
@@ -1,0 +1,159 @@
+import holidays
+import pandas as pd
+from django.conf import settings
+
+from parkings.models import ParkingArea, ParkingCount, Region
+
+
+def add_time_data_to_df(parking_df):
+    """
+    Adds holiday and time data to the DataFrame.
+
+    :param parking_df: Original Pandas DataFrame.
+    :type parking_df: pandas.DataFrame
+    :return: Pandas DataFrame with the time data.
+    :rtype: pandas.DataFrame
+    """
+
+    fi_holidays = holidays.CountryHoliday("FI")
+
+    def is_holiday(ds):
+        """
+        Checks if the given datetime stamp is a Finnish holiday
+
+        :param ds: Datetime stamp
+        :type ds: datetime
+        :return: 0 or 1 (boolean)
+        :rtype: int
+        """
+        if ds in fi_holidays:
+            return 1
+        else:
+            return 0
+
+    parking_df["ds"] = parking_df.index
+    parking_df["holiday"] = parking_df["ds"].apply(is_holiday)
+    parking_df = parking_df.drop(columns=["ds"])
+
+    parking_df["month"] = parking_df.index.month
+    parking_df["day_of_week"] = parking_df.index.dayofweek
+    parking_df["day_of_year"] = parking_df.index.dayofyear
+    parking_df["hour"] = parking_df.index.hour
+
+    return parking_df
+
+
+def get_region_parking_df():
+    """
+    Help funciton to construct the DataFrame for Region parkings.
+
+    :return: DataFrame of region parking data.
+    :rtype: pandas.DataFrame, list, int
+    """
+    parking_dict = {}
+    for region in Region.objects.all().order_by("name"):
+        region_name = region.name
+        parking_counts = (
+            ParkingCount.objects.filter(
+                is_forecast=False,
+                region=region,
+                time__gte=settings.FORECAST_PARKINGS_START,
+            )
+            .order_by("time")
+            .values("number")
+        )
+        if not parking_counts:
+            continue
+        if region_name not in parking_dict:
+            parking_dict[region_name] = []
+        for parking_count in parking_counts:
+            parking_dict[region_name].append(parking_count["number"])
+
+    if not parking_dict:
+        raise Exception("No cached ParkingCounts found.")
+
+    start_time = (
+        ParkingCount.objects.filter(
+            region__isnull=False,
+            is_forecast=False,
+            time__gte=settings.FORECAST_PARKINGS_START,
+        )
+        .order_by("time")
+        .first()
+        .time
+    )
+    end_time = (
+        ParkingCount.objects.filter(region__isnull=False, is_forecast=False)
+        .order_by("time")
+        .last()
+        .time
+    )
+    dti = pd.date_range(start_time, end_time, freq="H")
+    parking_df = pd.DataFrame(parking_dict, index=dti)
+    parking_df = parking_df.tz_convert("Europe/Helsinki")
+
+    # Clear regions with most frequent parking count being 0.
+    columns_to_drop = []
+    for region in parking_df.columns:
+        if parking_df[region].value_counts().idxmax() == 0:
+            columns_to_drop.append(region)
+    parking_df = parking_df.drop(columns=columns_to_drop)
+
+    # Remove extreme values.
+    for region in parking_df.columns:
+        hi = parking_df[[region]].quantile(0.999)[0]
+        parking_df[region] = parking_df[region].clip(lower=1, upper=hi)
+
+    return parking_df
+
+
+def get_parking_area_parking_df():
+    """
+    Help funciton to construct the DataFrame for ParkingArea parkings.
+
+    :return: DataFrame of parking area parking data.
+    :rtype: pandas.DataFrame
+    """
+    parking_dict = {}
+    for parking_area in ParkingArea.objects.all().order_by("origin_id"):
+        parking_area_id = parking_area.origin_id
+        parking_counts = (
+            ParkingCount.objects.filter(
+                is_forecast=False,
+                parking_area=parking_area,
+                time__gte=settings.FORECAST_PARKINGS_START,
+            )
+            .order_by("time")
+            .values("number")
+        )
+        if not parking_counts:
+            continue
+        if parking_area_id not in parking_dict:
+            parking_dict[parking_area_id] = []
+        for parking_count in parking_counts:
+            parking_dict[parking_area_id].append(parking_count["number"])
+
+    if not parking_dict:
+        raise Exception("No cached ParkingCounts found.")
+
+    start_time = (
+        ParkingCount.objects.filter(
+            parking_area__isnull=False,
+            is_forecast=False,
+            time__gte=settings.FORECAST_PARKINGS_START,
+        )
+        .order_by("time")
+        .first()
+        .time
+    )
+    end_time = (
+        ParkingCount.objects.filter(parking_area__isnull=False, is_forecast=False)
+        .order_by("time")
+        .last()
+        .time
+    )
+    dti = pd.date_range(start_time, end_time, freq="H")
+    parking_df = pd.DataFrame(parking_dict, index=dti)
+    parking_df = parking_df.tz_convert("Europe/Helsinki")
+
+    return parking_df

--- a/parkings/management/commands/forecast_region_parking_counts.py
+++ b/parkings/management/commands/forecast_region_parking_counts.py
@@ -1,0 +1,14 @@
+"""
+Train region model with cached parking data.
+"""
+from django.core.management.base import BaseCommand
+
+from parkings.forecasts.forecast_parking_counts import (
+    forecast_region_parking_counts)
+
+
+class Command(BaseCommand):
+    help = __doc__.strip().splitlines()[0]
+
+    def handle(self, *args, **options):
+        forecast_region_parking_counts()

--- a/parkings/tests/test_forecast_parking_counts.py
+++ b/parkings/tests/test_forecast_parking_counts.py
@@ -1,0 +1,185 @@
+import datetime
+from random import Random
+
+import pytest
+from django.conf import settings
+from django.utils.timezone import utc
+
+from parkings.forecasts.forecast_parking_counts import (
+    forecast_parking_area_parking_counts, forecast_region_parking_counts)
+from parkings.models import ParkingCount
+
+
+@pytest.mark.django_db
+def test_train_parking_area_model_with_no_parking_counts(
+    parking_area_factory, parking_count=100
+):
+    with pytest.raises(Exception) as e:
+        forecast_parking_area_parking_counts()
+    assert "No cached ParkingCounts found." in str(e)
+
+
+@pytest.mark.django_db
+def test_train_region_model_with_no_parking_counts(
+    parking_area_factory, parking_count=100
+):
+    with pytest.raises(Exception) as e:
+        forecast_region_parking_counts()
+    assert "No cached ParkingCounts found." in str(e)
+
+
+@pytest.mark.django_db
+def test_forecast_parking_area(parking_area_factory, parking_count=settings.FORECAST_PERIOD + 100):
+    start_time = datetime.datetime(2018, 1, 1, tzinfo=utc)
+    parking_area = parking_area_factory()
+    random = Random()
+    ParkingCount.objects.bulk_create(
+        (
+            ParkingCount(
+                number=random.randint(0, 500),
+                parking_area_id=parking_area.id,
+                time=start_time + datetime.timedelta(hours=i),
+            )
+            for i in range(parking_count)
+        )
+    )
+    final_datetime = ParkingCount.objects.latest("time").time
+
+    forecast_parking_area_parking_counts()
+
+    forecast_period_start = final_datetime + datetime.timedelta(hours=1)
+    forecast_period_end = final_datetime + datetime.timedelta(
+        hours=settings.FORECAST_PERIOD
+    )
+    after_forecast_period = final_datetime + datetime.timedelta(
+        hours=settings.FORECAST_PERIOD + 1
+    )
+    assert ParkingCount.objects.filter(
+        parking_area__isnull=False, is_forecast=True, time=forecast_period_start
+    ).exists()
+    assert ParkingCount.objects.filter(
+        parking_area__isnull=False, is_forecast=True, time=forecast_period_end
+    ).exists()
+    assert not ParkingCount.objects.filter(
+        parking_area__isnull=False, is_forecast=True, time=after_forecast_period
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_forecast_region(region_factory, parking_count=settings.FORECAST_PERIOD + 100):
+    start_time = datetime.datetime(2018, 1, 1, tzinfo=utc)
+    region = region_factory()
+    random = Random()
+    ParkingCount.objects.bulk_create(
+        (
+            ParkingCount(
+                number=random.randint(0, 500),
+                region_id=region.id,
+                time=start_time + datetime.timedelta(hours=i),
+            )
+            for i in range(parking_count)
+        )
+    )
+    final_datetime = ParkingCount.objects.latest("time").time
+
+    forecast_region_parking_counts()
+
+    forecast_period_start = final_datetime + datetime.timedelta(hours=1)
+    forecast_period_end = final_datetime + datetime.timedelta(
+        hours=settings.FORECAST_PERIOD
+    )
+    after_forecast_period = final_datetime + datetime.timedelta(
+        hours=settings.FORECAST_PERIOD + 1
+    )
+    assert ParkingCount.objects.filter(
+        region__isnull=False, is_forecast=True, time=forecast_period_start
+    ).exists()
+    assert ParkingCount.objects.filter(
+        region__isnull=False, is_forecast=True, time=forecast_period_end
+    ).exists()
+    assert not ParkingCount.objects.filter(
+        region__isnull=False, is_forecast=True, time=after_forecast_period
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_forecast_2_parking_areas(parking_area_factory, parking_count=settings.FORECAST_PERIOD + 100):
+    start_time = datetime.datetime(2018, 1, 1, tzinfo=utc)
+    random = Random()
+    parking_area = parking_area_factory(origin_id="1234")
+    ParkingCount.objects.bulk_create(
+        (
+            ParkingCount(
+                number=random.randint(0, 500),
+                parking_area_id=parking_area.id,
+                time=start_time + datetime.timedelta(hours=i),
+            )
+            for i in range(parking_count)
+        )
+    )
+    parking_area2 = parking_area_factory(origin_id="4321")
+    ParkingCount.objects.bulk_create(
+        (
+            ParkingCount(
+                number=random.randint(0, 500),
+                parking_area_id=parking_area2.id,
+                time=start_time + datetime.timedelta(hours=i),
+            )
+            for i in range(parking_count)
+        )
+    )
+    final_datetime = ParkingCount.objects.latest("time").time
+
+    forecast_parking_area_parking_counts()
+
+    forecast_period_end = final_datetime + datetime.timedelta(
+        hours=settings.FORECAST_PERIOD
+    )
+    assert ParkingCount.objects.filter(
+        parking_area=parking_area, is_forecast=True, time=forecast_period_end
+    ).exists()
+    assert ParkingCount.objects.filter(
+        parking_area=parking_area2, is_forecast=True, time=forecast_period_end
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_forecast_2_regions(region_factory, parking_count=settings.FORECAST_PERIOD + 100):
+    start_time = datetime.datetime(2018, 1, 1, tzinfo=utc)
+    random = Random()
+
+    region = region_factory(name="test1")
+    ParkingCount.objects.bulk_create(
+        (
+            ParkingCount(
+                number=random.randint(0, 500),
+                region_id=region.id,
+                time=start_time + datetime.timedelta(hours=i),
+            )
+            for i in range(parking_count)
+        )
+    )
+    region2 = region_factory(name="test2")
+    ParkingCount.objects.bulk_create(
+        (
+            ParkingCount(
+                number=random.randint(0, 500),
+                region_id=region2.id,
+                time=start_time + datetime.timedelta(hours=i),
+            )
+            for i in range(parking_count)
+        )
+    )
+    final_datetime = ParkingCount.objects.latest("time").time
+
+    forecast_region_parking_counts()
+
+    forecast_period_end = final_datetime + datetime.timedelta(
+        hours=settings.FORECAST_PERIOD
+    )
+    assert ParkingCount.objects.filter(
+        region=region, is_forecast=True, time=forecast_period_end
+    ).exists()
+    assert ParkingCount.objects.filter(
+        region=region2, is_forecast=True, time=forecast_period_end
+    ).exists()

--- a/parkkihubi/settings.py
+++ b/parkkihubi/settings.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 from datetime import timedelta
 
@@ -217,3 +218,7 @@ PARKKIHUBI_ENFORCEMENT_API_ENABLED = (
     env.bool('PARKKIHUBI_ENFORCEMENT_API_ENABLED', True))
 PARKKIHUBI_PERMITS_PRUNABLE_AFTER = timedelta(days=3)
 DEFAULT_ENFORCEMENT_DOMAIN = ('Helsinki', 'HKI')
+FORECAST_PARKINGS_START = datetime.date(
+    2017, 9, 20
+)  # The data has some inconsistent datapoints in the beginning. This is the start of the consistent part of the data.
+FORECAST_PERIOD = 24 * 7  # One week.

--- a/parkkihubi/settings.py
+++ b/parkkihubi/settings.py
@@ -218,6 +218,7 @@ PARKKIHUBI_ENFORCEMENT_API_ENABLED = (
     env.bool('PARKKIHUBI_ENFORCEMENT_API_ENABLED', True))
 PARKKIHUBI_PERMITS_PRUNABLE_AFTER = timedelta(days=3)
 DEFAULT_ENFORCEMENT_DOMAIN = ('Helsinki', 'HKI')
+ENABLE_FORECAST_CRON_JOB = False
 FORECAST_PARKINGS_START = datetime.date(
     2017, 9, 20
 )  # The data has some inconsistent datapoints in the beginning. This is the start of the consistent part of the data.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,7 @@ pycodestyle==2.5.0        # via autopep8
 pydocstyle==4.0.1
 pyflakes==2.1.1           # via autoflake
 pygments==2.5.2           # via ipython
-pyparsing==2.4.5          # via packaging
+pyparsing==2.4.7          # via packaging
 six==1.13.0               # via django-extensions, packaging, prompt-toolkit, tox, traitlets
 snowballstemmer==2.0.0    # via pydocstyle
 toml==0.10.0              # via tox
@@ -36,7 +36,7 @@ tox==3.14.2
 traitlets==4.3.3          # via ipython
 virtualenv==16.7.8        # via tox
 wcwidth==0.1.7            # via prompt-toolkit
-werkzeug==0.16.0
+werkzeug==1.0.0
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -19,7 +19,7 @@ packaging==19.2           # via pytest
 pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.8.0                 # via pytest
-pyparsing==2.4.5          # via packaging
+pyparsing==2.4.7          # via packaging
 pytest==5.3.1
 pytest-cov==2.8.1
 pytest-django==3.7.0

--- a/requirements.in
+++ b/requirements.in
@@ -28,3 +28,10 @@ django-cors-headers
 django-sanitized-dump
 python-memcached
 pytz
+
+# Parking Predictions
+catboost==0.23.1
+django-cron==0.5.1
+holidays==0.9.11
+pandas==0.25.1
+sklearn==0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,15 @@
 #
 --no-binary psycopg2
 
+catboost==0.23.1
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
+cycler==0.10.0            # via matplotlib
 database-sanitizer==1.1.0  # via django-sanitized-dump
 django==2.2.8
+django-common-helpers==0.9.2  # via django-cron
 django-cors-headers==3.2.0
+django-cron==0.5.1
 django-environ==0.4.5
 django-filter==2.2.0
 django-sanitized-dump==1.2.0
@@ -16,18 +20,34 @@ djangorestframework==3.10.3
 djangorestframework-gis==0.14
 djangorestframework-jwt==1.11.0  # via drf-jwt-2fa
 drf-jwt-2fa==0.3.0
+graphviz==0.14            # via catboost
+holidays==0.9.11
 idna==2.8                 # via requests
+joblib==0.14.1            # via scikit-learn
+kiwisolver==1.1.0         # via matplotlib
 lxml==4.4.2
+matplotlib==3.0.3         # via catboost
+numpy==1.18.1             # via catboost, matplotlib, pandas, scikit-learn, scipy
 owslib==0.19.0
+pandas==0.25.1
+plotly==4.7.1             # via catboost
 psycopg2==2.8.4
 pyjwt==1.7.1              # via djangorestframework-jwt
+pyparsing==2.4.7          # via matplotlib
 pyproj==2.4.2.post1       # via owslib
-python-dateutil==2.8.1    # via owslib
+python-dateutil==2.8.1    # via holidays, matplotlib, owslib, pandas
 python-memcached==1.59
 pytz==2019.3
 pyyaml==5.2               # via database-sanitizer, django-sanitized-dump
 raven==6.10.0
 requests==2.22.0          # via owslib
-six==1.13.0               # via database-sanitizer, django-sanitized-dump, python-dateutil, python-memcached
+retrying==1.3.3           # via plotly
+scikit-learn==0.22.1      # via sklearn
+scipy==1.4.1              # via catboost, scikit-learn
+six==1.13.0               # via catboost, cycler, database-sanitizer, django-sanitized-dump, holidays, plotly, python-dateutil, python-memcached, retrying
+sklearn==0.0
 sqlparse==0.3.0           # via django
 urllib3==1.25.7           # via requests
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools                # via kiwisolver


### PR DESCRIPTION
- Add some dependencies
- Functions for training a gradient boosting model to forecast parking counts based on historical data and predicting parking counts 1 week into the future using the trained model.
- Gradient boosting forecast model implemented with CatBoost library.
- Add cron jobs that caches the parking counts and makes the predictions daily. By default the jobs are turned off.