### PR TITLE
Document pruning of old PermitSeries

### DIFF
--- a/docs/api/enforcement.yaml
+++ b/docs/api/enforcement.yaml
@@ -447,6 +447,11 @@ paths:
     get:
       tags: ['Permit Series']
       summary: Get list of permit series
+      description: |-
+        Inactive permit series may be deleted from the system.
+        The time limit which defines which series are considered
+        for removal is 3 days by default, but may be configured by the
+        service administrator to a different value.
       operationId: getPermitSeriesList
       security: [{ApiKey: []}]
       responses:
@@ -464,6 +469,11 @@ paths:
     post:
       tags: ['Permit Series']
       summary: Create a permit series object
+      description: |-
+        Inactive permit series may be deleted from the system.
+        The time limit which defines which series are considered
+        for removal is 3 days by default, but may be configured by the
+        service administrator to a different value.
       operationId: createPermitSeries
       security: [{ApiKey: []}]
       requestBody:
@@ -515,10 +525,10 @@ paths:
         Activate the specified permit series and deactivate all other
         permit series owned by you.
 
-        As a side effect this will also delete old inactive permit
-        series from the system.  The time limit which defines which
-        series are considered old is 3 days by default, but may be
-        configured by the service administrator to a different value.
+        Inactive permit series may be deleted from the system.
+        The time limit which defines which series are considered
+        for removal is 3 days by default, but may be configured by the
+        service administrator to a different value.
       operationId: activatePermitSeries
       security: [{ApiKey: []}]
       parameters:

--- a/docs/api/operator.yaml
+++ b/docs/api/operator.yaml
@@ -770,6 +770,11 @@ paths:
     get:
       tags: ['Permit Series']
       summary: Get list of permit series
+      description: |-
+        Inactive permit series may be deleted from the system.
+        The time limit which defines which series are considered
+        for removal is 3 days by default, but may be configured by the
+        service administrator to a different value.
       operationId: getPermitSeriesList
       security: [{ApiKey: []}]
       responses:
@@ -787,6 +792,11 @@ paths:
     post:
       tags: ['Permit Series']
       summary: Create a permit series object
+      description: |-
+        Inactive permit series may be deleted from the system.
+        The time limit which defines which series are considered
+        for removal is 3 days by default, but may be configured by the
+        service administrator to a different value.
       operationId: createPermitSeries
       security: [{ApiKey: []}]
       requestBody:
@@ -855,10 +865,10 @@ paths:
         Activate the specified permit series and possibly deactivate
         some other permit series owned by you.
 
-        As a side effect this will also delete old inactive permit
-        series from the system.  The time limit which defines which
-        series are considered old is 3 days by default, but may be
-        configured by the service administrator to a different value.
+        Inactive permit series may be deleted from the system.
+        The time limit which defines which series are considered
+        for removal is 3 days by default, but may be configured by the
+        service administrator to a different value.
       operationId: activatePermitSeries
       security: [{ApiKey: []}]
       parameters:


### PR DESCRIPTION
Add a description to Operator and Enforcement API documents mentioning that inactive permits series are pruned automatically after a certain time.

Currently, the pruning is linked to activating new series, but this might be changed at some point and is not considered relevant, so no need to mention it in these endpoint descriptions.