### PR TITLE
Operator api: Add endpoint for PaymentZones

### DIFF
--- a/parkings/api/operator/urls.py
+++ b/parkings/api/operator/urls.py
@@ -5,6 +5,7 @@ from .parking import OperatorAPIParkingViewSet
 from .permit import (
     OperatorActivePermitByExternalIdViewSet, OperatorPermitSeriesViewSet,
     OperatorPermittedPermitAreaViewSet, OperatorPermitViewSet)
+from .zone import OperatorPermittedPaymentZoneViewSet
 
 router = DefaultRouter()
 router.register(r'parking', OperatorAPIParkingViewSet, basename='parking')
@@ -12,6 +13,7 @@ router.register(r'permitseries', OperatorPermitSeriesViewSet, basename='permitse
 router.register(r'permit', OperatorPermitViewSet, basename='permit')
 router.register(r'activepermit', OperatorActivePermitByExternalIdViewSet, basename='activepermit')
 router.register(r'permit_area', OperatorPermittedPermitAreaViewSet, basename='permitarea')
+router.register(r'payment_zone', OperatorPermittedPaymentZoneViewSet, basename='paymentzone')
 
 app_name = 'operator'
 urlpatterns = [

--- a/parkings/api/operator/zone.py
+++ b/parkings/api/operator/zone.py
@@ -1,0 +1,23 @@
+from rest_framework import mixins, serializers
+from rest_framework.viewsets import GenericViewSet
+
+from parkings.models import EnforcementDomain, PaymentZone
+
+from .permissions import IsOperator
+
+
+class PaymentZoneSerializer(serializers.ModelSerializer):
+    domain = serializers.SlugRelatedField(
+        slug_field='code', queryset=EnforcementDomain.objects.all())
+
+    class Meta:
+        model = PaymentZone
+        fields = ['domain', 'code', 'name']
+
+
+class OperatorPermittedPaymentZoneViewSet(mixins.ListModelMixin, GenericViewSet):
+    permission_classes = [IsOperator]
+    serializer_class = PaymentZoneSerializer
+
+    def get_queryset(self):
+        return PaymentZone.objects.filter(domain=self.request.user.enforcer.enforced_domain)

--- a/parkings/models/zone.py
+++ b/parkings/models/zone.py
@@ -19,6 +19,7 @@ class PaymentZone(TimestampedModelMixin, UUIDPrimaryKeyMixin):
 
     class Meta:
         unique_together = [('domain', 'code')]
+        ordering = ('domain', 'code')
 
     def __str__(self):
         return self.name

--- a/parkings/tests/api/operator/test_payment_zone.py
+++ b/parkings/tests/api/operator/test_payment_zone.py
@@ -1,0 +1,61 @@
+from django.urls import reverse
+from rest_framework.status import HTTP_200_OK
+
+from parkings.factories import EnforcerFactory
+from parkings.models import PaymentZone
+
+from ..enforcement.test_check_parking import create_area_geom
+
+list_url = reverse("operator:v1:paymentzone-list")
+
+
+def test_endpoint_returns_paymentzone_list(operator_api_client, operator):
+    enforcer = EnforcerFactory(user=operator.user)
+
+    zone = PaymentZone.objects.create(
+        domain=enforcer.enforced_domain,
+        code="1",
+        name="Maksuvyöhyke 1",
+        number=1,
+        geom=create_area_geom(),
+    )
+
+    response = operator_api_client.get(list_url)
+    json_response = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    assert json_response["count"] == 1
+    expected_keys = {"domain", "code", "name"}
+    assert set(json_response["results"][0]) == expected_keys
+    assert json_response["results"][0]["domain"] == zone.domain.code
+    assert json_response["results"][0]["code"] == "1"
+    assert json_response["results"][0]["name"] == "Maksuvyöhyke 1"
+
+
+def test_endpoint_returns_permitted_paymentzone_list(operator_api_client, operator, staff_user):
+    enforcer = EnforcerFactory(user=operator.user)
+    enforcer_2 = EnforcerFactory(user=staff_user)
+
+    PaymentZone.objects.create(
+        domain=enforcer.enforced_domain,
+        code="1",
+        name="Maksuvyöhyke 1",
+        number=1,
+        geom=create_area_geom(),
+    )
+
+    PaymentZone.objects.create(
+        domain=enforcer_2.enforced_domain,
+        code="2",
+        name="Maksuvyöhyke 2",
+        number=2,
+        geom=create_area_geom(),
+    )
+
+    response = operator_api_client.get(list_url)
+    json_response = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    assert json_response["count"] == 1
+    assert json_response["results"][0]["code"] == "1"
+    assert PaymentZone.objects.count() == 2


### PR DESCRIPTION
Add a new endpoint for listing PaymentZones for permitted operators.
This change has already been documented in fd7bf05.

Also, fix an `UnorderedObjectListWarning` by adding an ordering for the PaymentZone model.