### PR TITLE
Update migration 0020 for PaymentZone ordering

### DIFF
--- a/parkings/migrations/0020_add_paymentzone.py
+++ b/parkings/migrations/0020_add_paymentzone.py
@@ -27,6 +27,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'abstract': False,
+                'ordering': ('domain', 'code'),
             },
         ),
     ]


### PR DESCRIPTION
Ordering was added to PaymentZone Meta options in commit b76902e6c30,
but migrations were not updated, which cause makemigration to generate a
new (unneeded) migration file.  Fix that issue by adding the new option
to the existing 0020_add_paymentzone migration file.

It just a meta data change which doesn't actually change the database
schema (can be checked by generating the new migration and running
"./manage.py sqlmigrate 0036" where 0036 is the number of the generated
migration).  Therefore it's safe to add this ordering field change
directly to the already applied migration.