### PR TITLE
Enforcement: Enable fetching all valid parkings and permit items

### DIFF
--- a/parkings/api/enforcement/urls.py
+++ b/parkings/api/enforcement/urls.py
@@ -8,6 +8,7 @@ from .enforcement_permit import (
     EnforcementPermitViewSet)
 from .operator import OperatorViewSet
 from .valid_parking import ValidParkingViewSet
+from .valid_permit_item import ValidPermitItemViewSet
 
 
 class Router(DefaultRouter):
@@ -31,6 +32,7 @@ router.register('active_permit_by_external_id',
 router.register('permitseries', EnforcementPermitSeriesViewSet, basename='permitseries')
 router.register('valid_parking', ValidParkingViewSet,
                 basename='valid_parking')
+router.register('valid_permit_item', ValidPermitItemViewSet, basename='valid_permit_item')
 
 app_name = 'enforcement'
 urlpatterns = [

--- a/parkings/api/enforcement/valid_parking.py
+++ b/parkings/api/enforcement/valid_parking.py
@@ -48,7 +48,7 @@ class ValidParkingSerializer(serializers.ModelSerializer):
 
 class ValidParkingFilter(django_filters.rest_framework.FilterSet):
     reg_num = django_filters.CharFilter(
-        label=_("Registration number"), method='filter_reg_num', required=True)
+        label=_("Registration number"), method='filter_reg_num')
     time = django_filters.IsoDateTimeFilter(
         label=_("Time"), method='filter_time')
 
@@ -66,6 +66,12 @@ class ValidParkingFilter(django_filters.rest_framework.FilterSet):
             data = data.copy()
             data.setdefault('time', timezone.now())
         super().__init__(data, *args, **kwargs)
+
+    def is_valid(self):
+        super(ValidParkingFilter, self).is_valid()
+        if not self.request.query_params.get("reg_num") and not self.request.query_params.get("time"):
+            raise serializers.ValidationError(_("Either time or registration number required."))
+        return True
 
     def filter_reg_num(self, queryset, name, value):
         """

--- a/parkings/api/enforcement/valid_permit_item.py
+++ b/parkings/api/enforcement/valid_permit_item.py
@@ -1,0 +1,60 @@
+import django_filters
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers, viewsets
+
+from parkings.models import PermitArea
+
+from ...models import PermitLookupItem
+from .permissions import IsEnforcer
+
+
+class ValidPermitItemSerializer(serializers.ModelSerializer):
+    area = serializers.SlugRelatedField(slug_field='identifier', queryset=PermitArea.objects.all())
+    operator = serializers.CharField(source='permit.series.owner.operator.id')
+    operator_name = serializers.CharField(source='permit.series.owner.operator.name')
+
+    class Meta:
+        model = PermitLookupItem
+        fields = [
+            'area',
+            'registration_number',
+            'start_time',
+            'end_time',
+            'operator',
+            'operator_name',
+        ]
+
+
+class ValidPermitItemFilter(django_filters.rest_framework.FilterSet):
+    reg_num = django_filters.CharFilter(
+        label=_("Registration number"), method='filter_reg_num')
+    time = django_filters.IsoDateTimeFilter(
+        label=_("Time"), method='filter_time')
+
+    class Meta:
+        model = PermitLookupItem
+        fields = []
+
+    def is_valid(self):
+        super(ValidPermitItemFilter, self).is_valid()
+        if not self.request.query_params.get("reg_num") and not self.request.query_params.get("time"):
+            raise serializers.ValidationError(_("Either time or registration number required."))
+        else:
+            return True
+
+    def filter_reg_num(self, queryset, name, value):
+        return queryset.by_subject(value).active()
+
+    def filter_time(self, queryset, name, value):
+        valid_permits = queryset.by_time(value).active()
+        return valid_permits
+
+
+class ValidPermitItemViewSet(viewsets.ReadOnlyModelViewSet):
+    permission_classes = [IsEnforcer]
+    queryset = PermitLookupItem.objects.order_by('end_time')
+    serializer_class = ValidPermitItemSerializer
+    filterset_class = ValidPermitItemFilter
+
+    def get_queryset(self):
+        return super().get_queryset().filter(permit__domain=self.request.user.enforcer.enforced_domain)

--- a/parkings/tests/api/enforcement/test_valid_permit_item.py
+++ b/parkings/tests/api/enforcement/test_valid_permit_item.py
@@ -1,0 +1,156 @@
+import datetime
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.status import (
+    HTTP_400_BAD_REQUEST, HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN)
+
+from parkings.factories.permit import create_permit, create_permits
+from parkings.models import PermitLookupItem
+from parkings.tests.api.enforcement.test_valid_parking import iso8601
+
+from ..utils import (
+    ALL_METHODS, check_list_endpoint_base_fields, check_method_status_codes,
+    get)
+
+list_url = reverse('enforcement:v1:valid_permit_item-list')
+
+
+def list_url_for(reg_num=None, time=None):
+    assert reg_num or time
+    if not time:
+        return '{url}?reg_num={reg_num}'.format(url=list_url, reg_num=reg_num)
+    elif not reg_num:
+        return '{url}?time={time}'.format(url=list_url, time=iso8601(time))
+    else:
+        return '{url}?reg_num={reg_num}&time={time}'.format(url=list_url, reg_num=reg_num, time=iso8601(time))
+
+
+def get_url(kind, permit_item):
+    if kind == 'list':
+        return list_url_for(reg_num=permit_item.registration_number, time=timezone.now())
+    elif kind == 'list_by_reg_num':
+        return list_url_for(reg_num=permit_item.registration_number)
+    elif kind == 'list_by_reg_num_and_time':
+        return list_url_for(reg_num=permit_item.registration_number, time=timezone.now())
+    else:
+        assert kind == 'list_by_time'
+        return list_url_for(time=timezone.now())
+
+
+ALL_URL_KINDS = ['list', 'list_by_reg_num', 'list_by_reg_num_and_time', 'list_by_time']
+
+
+@pytest.mark.parametrize('url_kind', ALL_URL_KINDS)
+def test_permission_checks(api_client, operator_api_client, enforcer, url_kind):
+    create_permit(active=True, owner=enforcer.user, domain=enforcer.enforced_domain)
+    permit_item = PermitLookupItem.objects.first()
+    url = get_url(url_kind, permit_item)
+    check_method_status_codes(
+        api_client, [url], ALL_METHODS, HTTP_401_UNAUTHORIZED)
+    check_method_status_codes(
+        operator_api_client, [url], ALL_METHODS, HTTP_403_FORBIDDEN,
+        error_code='permission_denied')
+
+
+@pytest.mark.parametrize('url_kind', ALL_URL_KINDS)
+def test_disallowed_methods(enforcer_api_client, enforcer, url_kind):
+    create_permit(active=True, owner=enforcer.user, domain=enforcer.enforced_domain)
+    permit_item = PermitLookupItem.objects.first()
+    url = get_url(url_kind, permit_item)
+    disallowed_methods = ('post', 'put', 'patch', 'delete')
+    check_method_status_codes(
+        enforcer_api_client, [url], disallowed_methods, 405)
+
+
+def test_reg_num_or_time_is_required(enforcer_api_client):
+    response = enforcer_api_client.get(list_url)
+    error_message = 'Either time or registration number required.'
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert error_message in response.data
+
+
+def test_list_endpoint_base_fields(enforcer_api_client):
+    permit_item_data = get(enforcer_api_client, list_url_for(reg_num='ABC-123'))
+    check_list_endpoint_base_fields(permit_item_data)
+
+
+def test_list_endpoint_data(enforcer_api_client, enforcer, operator_factory):
+    operator_factory(user=enforcer.user)
+    create_permit(active=True, owner=enforcer.user, domain=enforcer.enforced_domain, subject_count=1, area_count=1)
+    assert PermitLookupItem.objects.count() == 1
+    permit_item = PermitLookupItem.objects.first()
+
+    data = get(enforcer_api_client, get_url('list_by_reg_num', permit_item))
+    assert len(data['results']) == 1
+
+    permit_item_data = data['results'][0]
+    check_permit_item_data_keys(permit_item_data)
+    check_permit_item_data_matches_permitlookuptem_object(data['results'][0], permit_item)
+
+
+def check_permit_item_data_keys(permit_item_data):
+    permit_item_data_keys = {
+        'area', 'registration_number', 'start_time', 'end_time', 'operator', 'operator_name',
+    }
+    assert set(permit_item_data.keys()) == permit_item_data_keys
+
+
+def check_permit_item_data_matches_permitlookuptem_object(permit_item_data, permit_item):
+    assert permit_item_data['area'] == permit_item.area.identifier
+    assert permit_item_data['registration_number'] == permit_item.registration_number
+    assert permit_item_data['start_time'] == iso8601(permit_item.start_time)
+    assert permit_item_data['end_time'] == iso8601(permit_item.end_time)
+    assert permit_item_data['operator'] == str(permit_item.permit.series.owner.operator.id)
+    assert permit_item_data['operator_name'] == permit_item.permit.series.owner.operator.name
+
+
+def test_registration_number_filter(enforcer_api_client, enforcer):
+    create_permits(active=True, owner=enforcer.user, domain=enforcer.enforced_domain)
+    for permit_item in PermitLookupItem.objects.all():
+        results = get(enforcer_api_client, list_url_for(reg_num=permit_item.registration_number))['results']
+        for result in results:
+            assert result['registration_number'] == permit_item.registration_number
+
+
+def test_time_filter(enforcer_api_client, enforcer):
+    create_permit(active=True, owner=enforcer.user, domain=enforcer.enforced_domain, subject_count=2, area_count=1)
+    permit_1 = PermitLookupItem.objects.all()[0]
+    permit_2 = PermitLookupItem.objects.all()[1]
+
+    response = get(enforcer_api_client, list_url_for(time=timezone.now()))
+    assert response['count'] == 2
+
+    permit_2.end_time = timezone.now() - datetime.timedelta(seconds=900)
+    permit_2.save()
+
+    response = get(enforcer_api_client, list_url_for(time=timezone.now()))
+    assert response['count'] == 1
+    assert response['results'][0]['registration_number'] == permit_1.registration_number
+
+
+def test_registration_number_and_time_filter(enforcer_api_client, enforcer):
+    create_permit(active=True, owner=enforcer.user, domain=enforcer.enforced_domain, subject_count=2, area_count=1)
+    permit_1 = PermitLookupItem.objects.first()
+
+    response = get(enforcer_api_client, list_url_for(reg_num=permit_1.registration_number, time=timezone.now()))
+
+    assert response['count'] == 1
+    assert response['results'][0]['registration_number'] == permit_1.registration_number
+
+
+def test_enforcer_can_view_only_permit_items_from_domain_they_enforce(enforcer_api_client, enforcer):
+    create_permits(active=True, owner=enforcer.user, domain=enforcer.enforced_domain, count=1)
+    create_permits(active=True, count=1)
+
+    enforcer_permits = PermitLookupItem.objects.filter(permit__domain=enforcer.enforced_domain)
+
+    assert PermitLookupItem.objects.count() == 12
+    assert enforcer_permits.count() == 6
+
+    response = get(enforcer_api_client, list_url_for(time=timezone.now()))
+
+    assert response['count'] == 6
+    for results in response['results']:
+        assert results['registration_number'] in enforcer_permits.values_list('registration_number', flat=True)


### PR DESCRIPTION
Remove the registration number as a required parameter from valid parking endpoint, enabling all valid parkings to be fetched. However, either time or registration number is required.

Add an endpoint for fetching valid permits for enforcers. Endpoint requires either registration number or time parameter for filtering.