### PR TITLE
valid_parking: Change zone field definition (HP-104)

### DIFF
--- a/parkings/api/enforcement/valid_parking.py
+++ b/parkings/api/enforcement/valid_parking.py
@@ -6,14 +6,19 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, viewsets
 
-from ...models import Parking, PaymentZone
+from ...models import Parking
 from .permissions import IsEnforcer
+
+
+class CharOrIntegerField(serializers.CharField):
+    def to_representation(self, value):
+        str_value = super().to_representation(value)
+        return int(str_value) if str_value.isdigit() else str_value
 
 
 class ValidParkingSerializer(serializers.ModelSerializer):
     operator_name = serializers.CharField(source='operator.name')
-    zone = serializers.SlugRelatedField(
-        slug_field='code', queryset=PaymentZone.objects.all())
+    zone = CharOrIntegerField(source='zone.code')
 
     class Meta:
         model = Parking
@@ -32,8 +37,6 @@ class ValidParkingSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)
-
-        representation['zone'] = instance.zone.casted_code
 
         if not instance.is_disc_parking:
             representation.pop('is_disc_parking')

--- a/parkings/tests/api/enforcement/test_valid_parking.py
+++ b/parkings/tests/api/enforcement/test_valid_parking.py
@@ -252,6 +252,8 @@ def test_endpoint_returns_parkings_with_same_zone_code_in_correct_domain(
     domain = staff_user.enforcer.enforced_domain
     zone_2 = create_payment_zone(code='Z', domain=domain)
 
+    assert zone_1.domain.code != zone_2.domain.code
+
     parking_1 = parking_factory(registration_number="ABC-123", operator=operator, zone=zone_1)
     parking_1.domain = zone_1.domain
     parking_1.save()
@@ -264,8 +266,10 @@ def test_endpoint_returns_parkings_with_same_zone_code_in_correct_domain(
     assert len(data_1['results']) == 1
     parking_data_1 = data_1['results'][0]
     assert parking_data_1['id'] == str(parking_1.id)
+    assert parking_data_1['zone'] == 'Z'
 
     data_2 = get(staff_api_client, get_url('list_by_reg_num', parking_2))
     assert len(data_2['results']) == 1
     parking_data_2 = data_2['results'][0]
     assert parking_data_2['id'] == str(parking_2.id)
+    assert parking_data_2['zone'] == 'Z'


### PR DESCRIPTION
Define a new field type CharOrIntegerField for the zone field to make it
clearer that the returned value could actually be either string or
integer and to avoid loading the PaymentZone object from the database.

Also add a few asserts to the related test case to make sure that the
created two zones are actually in different domains and that the
returned zone code is correct.