### PR TITLE
Fix valid_parking for disc parkings and improve tests (HP-106)

### DIFF
--- a/parkings/api/enforcement/valid_parking.py
+++ b/parkings/api/enforcement/valid_parking.py
@@ -10,15 +10,8 @@ from ...models import Parking
 from .permissions import IsEnforcer
 
 
-class CharOrIntegerField(serializers.CharField):
-    def to_representation(self, value):
-        str_value = super().to_representation(value)
-        return int(str_value) if str_value.isdigit() else str_value
-
-
 class ValidParkingSerializer(serializers.ModelSerializer):
     operator_name = serializers.CharField(source='operator.name')
-    zone = CharOrIntegerField(source='zone.code')
 
     class Meta:
         model = Parking
@@ -37,6 +30,9 @@ class ValidParkingSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)
+
+        if instance.zone:
+            representation['zone'] = instance.zone.casted_code
 
         if not instance.is_disc_parking:
             representation.pop('is_disc_parking')

--- a/parkings/factories/parking.py
+++ b/parkings/factories/parking.py
@@ -48,6 +48,7 @@ class ParkingFactory(factory.django.DjangoModelFactory):
 
 class DiscParkingFactory(ParkingFactory):
     is_disc_parking = True
+    time_end = None
     zone = None
 
 

--- a/parkings/factories/parking.py
+++ b/parkings/factories/parking.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from datetime import timedelta
 
 import factory
@@ -46,6 +48,7 @@ class ParkingFactory(factory.django.DjangoModelFactory):
 
 class DiscParkingFactory(ParkingFactory):
     is_disc_parking = True
+    zone = None
 
 
 def get_time_far_enough_in_past():

--- a/parkings/tests/api/enforcement/test_valid_parking.py
+++ b/parkings/tests/api/enforcement/test_valid_parking.py
@@ -132,10 +132,14 @@ def check_parking_data_matches_parking_object(parking_data, parking_obj):
 
 
 def iso8601(dt):
+    if not dt:
+        return None
     return dt.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
 def iso8601_us(dt):
+    if not dt:
+        return None
     return dt.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
 

--- a/parkings/tests/api/enforcement/test_valid_parking.py
+++ b/parkings/tests/api/enforcement/test_valid_parking.py
@@ -119,7 +119,8 @@ def check_parking_data_matches_parking_object(parking_data, parking_obj):
     Check that a parking data dict and an actual Parking object match.
     """
     assert parking_data['registration_number'] == getattr(parking_obj, 'registration_number')
-    assert parking_data['zone'] == parking_obj.zone.casted_code
+    assert parking_data['zone'] == (parking_obj.zone.casted_code
+                                    if parking_obj.zone else None)
     assert parking_data['id'] == str(parking_obj.id)  # UUID -> str
     assert parking_data['operator'] == str(parking_obj.operator.id)
     assert parking_data['created_at'] == iso8601_us(parking_obj.created_at)
@@ -234,11 +235,10 @@ def test_enforcer_can_view_only_parkings_from_domain_they_enforce(
     assert response['results'][0]['id'] == str(visible_parking.id)
 
 
-@pytest.mark.parametrize("parking_type", ALL_PARKING_KINDS)
 def test_endpoint_can_return_zone_as_string_or_integer(
-    enforcer_api_client, parking_type, parking, disc_parking, enforcer
+    enforcer_api_client, parking, enforcer
 ):
-    parking_object = get_parking_object(parking_type, parking, disc_parking)
+    parking_object = parking
     parking_object.domain = enforcer.enforced_domain
     parking_object.save()
 

--- a/parkings/tests/api/operator/test_disc_parking.py
+++ b/parkings/tests/api/operator/test_disc_parking.py
@@ -44,10 +44,19 @@ def test_post_disc_parking(operator_api_client, operator, disc_parking_data):
         assert response_parking_data[key] == disc_parking_data[key]
 
 
-def test_end_disc_parking_with_patch(operator_api_client, operator, disc_parking):
+@pytest.mark.parametrize('kind', ['had time_end', 'didnt have time_end'])
+def test_end_disc_parking_with_patch(
+        kind, operator_api_client, operator, disc_parking):
     detail_url = get_detail_url(disc_parking)
 
-    new_time_end = disc_parking.time_end + datetime.timedelta(days=1)
+    if kind == 'had time_end':
+        disc_parking.time_end = (
+            disc_parking.time_start + datetime.timedelta(hours=5))
+    else:
+        disc_parking.time_end = None
+    disc_parking.save()
+
+    new_time_end = disc_parking.time_start + datetime.timedelta(hours=2)
     time_end = new_time_end.strftime('%Y-%m-%dT%H:%M:%SZ')
 
     patch(operator_api_client, detail_url, data={'time_end': time_end})


### PR DESCRIPTION
The valid_parking endpoint was failing for disc parkings, since they
don't have a zone and it tried to access "zone.code".  Fix this and
fix the DiscParkingFactory to generate parkings without a zone so that
those cases are also tested.

Another very similar special case are parkings with time_end value, so
while at it, also make sure that those are handled.