### PR TITLE
Improve GeoJSON importers (HP-91)

### DIFF
--- a/parkings/importers/geojson_importer.py
+++ b/parkings/importers/geojson_importer.py
@@ -3,10 +3,13 @@ import json
 
 from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Polygon
 
+from ..models import EnforcementDomain
+
 
 class GeoJsonImporter(metaclass=abc.ABCMeta):
-    def __init__(self, srid=None):
+    def __init__(self, srid=None, default_domain_code=None):
         self.srid = srid
+        self.default_domain_code = default_domain_code
 
     def read_and_parse(self, geojson_file_path):
         with open(geojson_file_path, "rt") as file:
@@ -28,3 +31,8 @@ class GeoJsonImporter(metaclass=abc.ABCMeta):
             result.srid = self.srid
 
         return result
+
+    def get_default_domain(self):
+        if self.default_domain_code:
+            return EnforcementDomain.objects.get(code=self.default_domain_code)
+        return EnforcementDomain.get_default_domain()

--- a/parkings/importers/geojson_importer.py
+++ b/parkings/importers/geojson_importer.py
@@ -1,7 +1,7 @@
 import abc
 import json
 
-from django.contrib.gis.geos import GEOSGeometry
+from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Polygon
 
 
 class GeoJsonImporter(metaclass=abc.ABCMeta):
@@ -17,4 +17,9 @@ class GeoJsonImporter(metaclass=abc.ABCMeta):
         pass
 
     def get_polygons(self, geom):
-        return GEOSGeometry(json.dumps(geom))
+        result = GEOSGeometry(json.dumps(geom))
+
+        if isinstance(result, Polygon):
+            result = MultiPolygon(result)
+
+        return result

--- a/parkings/importers/geojson_importer.py
+++ b/parkings/importers/geojson_importer.py
@@ -5,6 +5,8 @@ from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Polygon
 
 
 class GeoJsonImporter(metaclass=abc.ABCMeta):
+    def __init__(self, srid=None):
+        self.srid = srid
 
     def read_and_parse(self, geojson_file_path):
         with open(geojson_file_path, "rt") as file:
@@ -21,5 +23,8 @@ class GeoJsonImporter(metaclass=abc.ABCMeta):
 
         if isinstance(result, Polygon):
             result = MultiPolygon(result)
+
+        if self.srid:
+            result.srid = self.srid
 
         return result

--- a/parkings/importers/geojson_payment_zones.py
+++ b/parkings/importers/geojson_payment_zones.py
@@ -3,8 +3,7 @@ import os
 
 from django.db import transaction
 
-from parkings.models import EnforcementDomain, PaymentZone
-
+from ..models import PaymentZone
 from .geojson_importer import GeoJsonImporter
 
 logger = logging.getLogger(__name__)
@@ -25,7 +24,7 @@ class PaymentZoneImporter(GeoJsonImporter):
     @transaction.atomic
     def _save_payment_zones(self, payment_zone_dicts):
         logger.info('Saving payment zones.')
-        default_domain = EnforcementDomain.get_default_domain()
+        default_domain = self.get_default_domain()
         count = 0
         payment_zone_ids = []
         for payment_dict in payment_zone_dicts:

--- a/parkings/importers/geojson_payment_zones.py
+++ b/parkings/importers/geojson_payment_zones.py
@@ -37,7 +37,6 @@ class PaymentZoneImporter(GeoJsonImporter):
                 defaults=payment_dict)
             payment_zone_ids.append(payment_zone.pk)
             count += 1
-        PaymentZone.objects.exclude(pk__in=payment_zone_ids).delete()
         return count
 
     def _parse_member(self, member):

--- a/parkings/importers/geojson_permit_areas.py
+++ b/parkings/importers/geojson_permit_areas.py
@@ -38,7 +38,6 @@ class PermitAreaImporter(GeoJsonImporter):
                 defaults=area_dict)
             permit_area_ids.append(permit_area.pk)
             count += 1
-        PermitArea.objects.exclude(pk__in=permit_area_ids).delete()
         return count
 
     def _parse_member(self, member):

--- a/parkings/importers/geojson_permit_areas.py
+++ b/parkings/importers/geojson_permit_areas.py
@@ -4,8 +4,7 @@ import os
 from django.contrib.auth import get_user_model
 from django.db import transaction
 
-from parkings.models import EnforcementDomain, PermitArea
-
+from ..models import PermitArea
 from .geojson_importer import GeoJsonImporter
 
 logger = logging.getLogger(__name__)
@@ -26,7 +25,7 @@ class PermitAreaImporter(GeoJsonImporter):
     def _save_permit_areas(self, permit_areas_dict, permitted_user):
         logger.info('Saving permit areas.')
         user = get_user_model().objects.filter(username=permitted_user).get()
-        default_domain = EnforcementDomain.get_default_domain()
+        default_domain = self.get_default_domain()
         count = 0
         permit_area_ids = []
         for area_dict in permit_areas_dict:

--- a/parkings/management/commands/import_geojson_payment_zones.py
+++ b/parkings/management/commands/import_geojson_payment_zones.py
@@ -8,7 +8,9 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('geojson_file_path')
+        parser.add_argument('--srid', '-s', type=int, default=None)
 
-    def handle(self, *args, **options):
-        file_path = options.get('geojson_file_path', None)
-        PaymentZoneImporter().import_payment_zones(file_path)
+    def handle(self, *, geojson_file_path,
+               srid=None, **kwargs):
+        importer = PaymentZoneImporter(srid=srid)
+        importer.import_payment_zones(geojson_file_path)

--- a/parkings/management/commands/import_geojson_payment_zones.py
+++ b/parkings/management/commands/import_geojson_payment_zones.py
@@ -9,8 +9,9 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('geojson_file_path')
         parser.add_argument('--srid', '-s', type=int, default=None)
+        parser.add_argument('--domain', '-d', type=str, default=None)
 
     def handle(self, *, geojson_file_path,
-               srid=None, **kwargs):
-        importer = PaymentZoneImporter(srid=srid)
+               srid=None, domain=None, **kwargs):
+        importer = PaymentZoneImporter(srid=srid, default_domain_code=domain)
         importer.import_payment_zones(geojson_file_path)

--- a/parkings/management/commands/import_geojson_permit_areas.py
+++ b/parkings/management/commands/import_geojson_permit_areas.py
@@ -8,9 +8,10 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('geojson_file_path')
-        parser.add_argument('permitted-user')
+        parser.add_argument('permitted_user')
+        parser.add_argument('--srid', '-s', type=int, default=None)
 
-    def handle(self, *args, **options):
-        file_path = options.get('geojson_file_path', None)
-        permitted_user = options.get('permitted-user', None)
-        PermitAreaImporter().import_permit_areas(file_path, permitted_user)
+    def handle(self, *, geojson_file_path, permitted_user,
+               srid=None, **kwargs):
+        importer = PermitAreaImporter(srid=srid)
+        importer.import_permit_areas(geojson_file_path, permitted_user)

--- a/parkings/management/commands/import_geojson_permit_areas.py
+++ b/parkings/management/commands/import_geojson_permit_areas.py
@@ -10,8 +10,9 @@ class Command(BaseCommand):
         parser.add_argument('geojson_file_path')
         parser.add_argument('permitted_user')
         parser.add_argument('--srid', '-s', type=int, default=None)
+        parser.add_argument('--domain', '-d', type=str, default=None)
 
     def handle(self, *, geojson_file_path, permitted_user,
-               srid=None, **kwargs):
-        importer = PermitAreaImporter(srid=srid)
+               srid=None, domain=None, **kwargs):
+        importer = PermitAreaImporter(srid=srid, default_domain_code=domain)
         importer.import_permit_areas(geojson_file_path, permitted_user)


### PR DESCRIPTION
Make it possible to specify the Enforcement Domain and the SRID of the
input data when importing from GeoJSON files.

Remove the code that deletes everything else than the imported areas.