### PR TITLE
GeoJSON importers: Improve properties passing

### DIFF
--- a/parkings/importers/geojson_importer.py
+++ b/parkings/importers/geojson_importer.py
@@ -17,9 +17,9 @@ class GeoJsonImporter(metaclass=abc.ABCMeta):
             for member in root['features']:
                 yield self._parse_member(member)
 
-    @abc.abstractmethod
     def _parse_member(self, member):
-        pass
+        props = member['properties']
+        return dict(props, geom=self.get_polygons(member['geometry']))
 
     def get_polygons(self, geom):
         result = GEOSGeometry(json.dumps(geom))

--- a/parkings/importers/geojson_payment_zones.py
+++ b/parkings/importers/geojson_payment_zones.py
@@ -29,7 +29,7 @@ class PaymentZoneImporter(GeoJsonImporter):
         payment_zone_ids = []
         for payment_dict in payment_zone_dicts:
             domain = payment_dict.pop('domain', default_domain)
-            code = payment_dict.pop('code', payment_dict.get('number'))
+            code = payment_dict.pop('code', str(payment_dict.get('number')))
             payment_zone, _ = PaymentZone.objects.update_or_create(
                 code=code,
                 domain=domain,
@@ -37,14 +37,3 @@ class PaymentZoneImporter(GeoJsonImporter):
             payment_zone_ids.append(payment_zone.pk)
             count += 1
         return count
-
-    def _parse_member(self, member):
-        name = member['properties']['name']
-        number = member['properties']['number']
-        geom = self.get_polygons(member['geometry'])
-
-        return {
-            'name': name,
-            'number': number,
-            'geom': geom,
-        }

--- a/parkings/importers/geojson_permit_areas.py
+++ b/parkings/importers/geojson_permit_areas.py
@@ -38,14 +38,3 @@ class PermitAreaImporter(GeoJsonImporter):
             permit_area_ids.append(permit_area.pk)
             count += 1
         return count
-
-    def _parse_member(self, member):
-        identifier = member['properties']['identifier']
-        name = member['properties']['name']
-        geom = self.get_polygons(member['geometry'])
-
-        return {
-            'name': name,
-            'identifier': identifier,
-            'geom': geom,
-        }


### PR DESCRIPTION
Pass the properties dict as is to the defaults argument in
get_or_create.  This makes the PaymentZone importer work also for zones
that have non-integer domains, since previously it was requred to put
the code to a field named "number", but when that was passed in the
"defaults" argument of get_or_create, it resulted to an error, because
non-integer was tried to be saved to an integer field.