### PR TITLE
api/operator: Fix PaymentZone list filtering (HP-107)

### DIFF
--- a/parkings/api/operator/urls.py
+++ b/parkings/api/operator/urls.py
@@ -5,7 +5,7 @@ from .parking import OperatorAPIParkingViewSet
 from .permit import (
     OperatorActivePermitByExternalIdViewSet, OperatorPermitSeriesViewSet,
     OperatorPermittedPermitAreaViewSet, OperatorPermitViewSet)
-from .zone import OperatorPermittedPaymentZoneViewSet
+from .zone import PaymentZoneViewSet
 
 router = DefaultRouter()
 router.register(r'parking', OperatorAPIParkingViewSet, basename='parking')
@@ -13,7 +13,7 @@ router.register(r'permitseries', OperatorPermitSeriesViewSet, basename='permitse
 router.register(r'permit', OperatorPermitViewSet, basename='permit')
 router.register(r'activepermit', OperatorActivePermitByExternalIdViewSet, basename='activepermit')
 router.register(r'permit_area', OperatorPermittedPermitAreaViewSet, basename='permitarea')
-router.register(r'payment_zone', OperatorPermittedPaymentZoneViewSet, basename='paymentzone')
+router.register(r'payment_zone', PaymentZoneViewSet, basename='paymentzone')
 
 app_name = 'operator'
 urlpatterns = [

--- a/parkings/api/operator/zone.py
+++ b/parkings/api/operator/zone.py
@@ -15,9 +15,7 @@ class PaymentZoneSerializer(serializers.ModelSerializer):
         fields = ['domain', 'code', 'name']
 
 
-class OperatorPermittedPaymentZoneViewSet(mixins.ListModelMixin, GenericViewSet):
+class PaymentZoneViewSet(mixins.ListModelMixin, GenericViewSet):
     permission_classes = [IsOperator]
     serializer_class = PaymentZoneSerializer
-
-    def get_queryset(self):
-        return PaymentZone.objects.filter(domain=self.request.user.enforcer.enforced_domain)
+    queryset = PaymentZone.objects.all()

--- a/parkings/tests/api/operator/test_payment_zone.py
+++ b/parkings/tests/api/operator/test_payment_zone.py
@@ -32,12 +32,14 @@ def test_endpoint_returns_paymentzone_list(operator_api_client, operator):
     assert json_response["results"][0]["name"] == "Maksuvyöhyke 1"
 
 
-def test_endpoint_returns_permitted_paymentzone_list(operator_api_client, operator, staff_user):
-    enforcer = EnforcerFactory(user=operator.user)
-    enforcer_2 = EnforcerFactory(user=staff_user)
+def test_endpoint_returns_all_paymentzones(
+        operator_api_client, operator, staff_user):
+    enforcer = EnforcerFactory(user=staff_user)
+    domain = enforcer.enforced_domain
+    assert not hasattr(operator_api_client.auth_user, 'enforcer')
 
     PaymentZone.objects.create(
-        domain=enforcer.enforced_domain,
+        domain=domain,
         code="1",
         name="Maksuvyöhyke 1",
         number=1,
@@ -45,7 +47,7 @@ def test_endpoint_returns_permitted_paymentzone_list(operator_api_client, operat
     )
 
     PaymentZone.objects.create(
-        domain=enforcer_2.enforced_domain,
+        domain=domain,
         code="2",
         name="Maksuvyöhyke 2",
         number=2,
@@ -53,9 +55,12 @@ def test_endpoint_returns_permitted_paymentzone_list(operator_api_client, operat
     )
 
     response = operator_api_client.get(list_url)
-    json_response = response.json()
 
+    json_response = response.json()
     assert response.status_code == HTTP_200_OK
-    assert json_response["count"] == 1
-    assert json_response["results"][0]["code"] == "1"
+    assert json_response["count"] == 2
+    assert json_response["results"] == [
+        {'code': '1', 'domain': domain.code, 'name': 'Maksuvyöhyke 1'},
+        {'code': '2', 'domain': domain.code, 'name': 'Maksuvyöhyke 2'},
+    ]
     assert PaymentZone.objects.count() == 2


### PR DESCRIPTION
The PaymentZone list should not be filtered in the Operator API, but
instead all payment zones should be returned.