### PR TITLE
Fix active_permit_by_external_id series filtering

### DIFF
--- a/parkings/api/common_permit.py
+++ b/parkings/api/common_permit.py
@@ -135,10 +135,14 @@ class ActivePermitByExternalIdViewSet(viewsets.ModelViewSet):
     lookup_field = 'external_id'
 
     def perform_create(self, serializer):
-        latest_active_permit_series = PermitSeries.objects.latest_active()
+        latest_active_permit_series = (
+            self.get_series_queryset().latest_active())
         if not latest_active_permit_series:
             raise NotFound(_("Active permit series doesn't exist"))
         serializer.save(series=latest_active_permit_series)
 
     def get_queryset(self):
         return super().get_queryset().filter(series__owner=self.request.user)
+
+    def get_series_queryset(self):
+        return PermitSeries.objects.filter(owner=self.request.user)


### PR DESCRIPTION
The active_permit_by_external_id endpoints in Enforcement API and
Operator API should operate on the latest active PermitSeries of the
user who is performing the request.  It used to operate on the latest
active PermitSeries regardless of the owner of the series, which made
that endpoint to create the permits to incorrect series some times.

Fix the endpoints by adding correct filtering to the base class
ActivePermitByExternalIdViewSet and add a test case as a regression test
for this bug.