### PR TITLE
Couple fixes to Enforcement and Operator API documentation

### DIFF
--- a/docs/api/enforcement.yaml
+++ b/docs/api/enforcement.yaml
@@ -9,7 +9,7 @@ info:
     **Note**: This is a review version of the API specification.  The
     specification contains some parts that are not yet frozen and their
     contents might change before the final non-review version.
-  version: "1.2.0.rc2.2020-04-24"  # remove above warning when releasing 1.2.0
+  version: "1.2.0.rc3.2020-05-18"  # remove above warning when releasing 1.2.0
 servers:
   - url: https://api.parkkiopas.fi/enforcement/v1/
     description: Production server

--- a/docs/api/enforcement.yaml
+++ b/docs/api/enforcement.yaml
@@ -210,7 +210,7 @@ components:
           description: Start time of the validity period
           type: string
           format: date-time
-        end_date:
+        end_time:
           description: End time of the validity period
           type: string
           format: date-time
@@ -232,7 +232,7 @@ components:
           description: Start time of the parking
           type: string
           format: date-time
-        end_date:
+        end_time:
           description: End time of the parking
           type: string
           format: date-time

--- a/docs/api/operator.yaml
+++ b/docs/api/operator.yaml
@@ -1081,7 +1081,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-  /active_permit_by_external_id/:
+  /activepermit/:
     get:
       tags: ['Active Permits by External Id']
       summary: Get list of permits in the active series
@@ -1131,7 +1131,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Permit'
-  /active_permit_by_external_id/{external_id}/:
+  /activepermit/{external_id}/:
     get:
       tags: ['Active Permits by External Id']
       summary: Get details of a permit in the active series

--- a/docs/api/operator.yaml
+++ b/docs/api/operator.yaml
@@ -30,9 +30,6 @@ tags:
   - name: Parkings
     description: >-
       Endpoints for creating and updating parkings
-  - name: Parking Information Queries
-    description: >-
-      Endpoint for performing parking spot information queries
   - name: Permit Series
     description: >-
       Creating, listing and activating permit series
@@ -171,92 +168,6 @@ components:
           items:
             type: number
             format: float
-    ParkingInfo:
-      description: Parking spot information
-      type: object
-      example:
-        location:
-          type: "Point"
-          coordinates: [24.938466, 60.170014]
-        terminal_number: "34B"
-        domain: "HKI"
-        zone: "2"
-        rules:
-          - after: "2019-11-15T06:00:00Z"
-            policy: "disc"
-            maximum_duration: 120
-          - after: "2019-11-15T16:00:00Z"
-            policy: "free"
-          - after: "2019-11-16T07:00:00Z"
-            policy: "disc"
-            maximum_duration: 120
-          - after: "2019-11-16T13:00:00Z"
-            policy: "free"
-          - after: "2019-11-17T02:00:00Z"
-            policy: "denied"
-          - after: "2019-11-18T02:00:00Z"
-            policy: "free"
-          - after: "2019-11-18T06:00:00Z"
-            policy: "disc"
-            maximum_duration: 120
-          - after: "2019-11-18T16:00:00Z"
-            policy: "free"
-          - after: "2019-11-19T02:00:00Z"
-            policy: "unknown"
-      required:
-        - location
-        - zone
-        - rules
-      properties:
-        location:
-          $ref: '#/components/schemas/Location'
-        terminal_number:
-          description: >-
-            Number of the closest payment terminal, if there is any near
-            the given location.
-          type: string
-        zone:
-          << : *parkingZone
-          description: Payment zone code of the parking spot
-        rules:
-          description: >-
-            List of rules that determine if parking is allowed and on
-            what conditions.  Each rule is valid for a time period
-            starting from the "after" timestamp specified in the rule
-            and ending to "after" timestamp of the next rule.
-          type: array
-          maxItems: 100
-          items:
-            type: object
-            required:
-              - after
-              - policy
-            properties:
-              after:
-                description: Start time of this rule
-                type: string
-                format: dateTime
-              policy:
-                description: >-
-                  What kind of parking is allowed during this period.
-
-                  Options are:
-                    * `paid`: Must pay the parking fee
-                    * `disc`: Must use a parking disc (regular or digital)
-                    * `free`: Parking is allowed for free without a disc
-                    * `denied`: Parking is not allowed
-                    * `unknown`: There is no information available
-                type: string
-                enum: ["paid", "disc", "free", "denied", "unknown"]
-              maximum_duration:
-                description: >-
-                  Maximum duration of parking during this period, in
-                  minutes.
-
-                  Note: Start times of parking disc parkings are rounded
-                  to next half hour, which might allow almost 30 minutes
-                  more parking time in practice.
-                type: integer
     PaymentZone:
       type: object
       example:
@@ -681,57 +592,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
-  /parking_info_query/:
-    post:
-      tags: ['Parking Information Queries']
-      summary: Query parking spot information
-      operationId: queryParkingInfo
-      security: [{ApiKey: []}]
-      requestBody:
-        required: true
-        description: Location of the parking spot to query
-        content:
-          application/json:
-            schema:
-              anyOf:
-                - title: By GPS coordinates
-                  example:
-                    location:
-                      type: Point
-                      coordinates: [24.938466, 60.170014]
-                  type: object
-                  properties:
-                    location:
-                      $ref: '#/components/schemas/Location'
-                  required:
-                    - location
-                - title: By payment terminal number
-                  example:
-                    terminal_number: "34B"
-                  type: object
-                  properties:
-                    terminal_number:
-                      description: Payment terminal number
-                      type: string
-                    domain:
-                      description: Code of the enforcement domain
-                      type: string
-                  required:
-                    - terminal_number
-                    - domain
-      responses:
-        '200':
-          description: Parking spot information query succeeded
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ParkingInfo'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
   /payment_zone/:
     get:
       tags: ['Payment Zones']

--- a/docs/api/operator.yaml
+++ b/docs/api/operator.yaml
@@ -9,7 +9,7 @@ info:
     **Note**: This is a review version of the API specification.  The
     specification contains some parts that are not yet frozen and their
     contents might change before the final non-review version.
-  version: "1.2.0.rc2.2020-04-24"
+  version: "1.2.0.rc3.2020-05-18"
 servers:
   - url: https://api.parkkiopas.fi/operator/v1/
     description: Production server

--- a/docs/api/operator.yaml
+++ b/docs/api/operator.yaml
@@ -340,7 +340,7 @@ components:
           description: Start time of the validity period
           type: string
           format: date-time
-        end_date:
+        end_time:
           description: End time of the validity period
           type: string
           format: date-time
@@ -362,7 +362,7 @@ components:
           description: Start time of the parking
           type: string
           format: date-time
-        end_date:
+        end_time:
           description: End time of the parking
           type: string
           format: date-time


### PR DESCRIPTION
Fix activepermit endpoint URLs.

Fix "end_date" field name to correct name "end_time".

Remove the parking_info_query endpoint documentation, since it's not
implemented yet.

Update the documentation versions to 1.2.0.rc3.  (Hopefully last rc
before actual release version of the docs.)