### PR TITLE
requirements-cov: Update codecov and coverage

### DIFF
--- a/requirements-cov.txt
+++ b/requirements-cov.txt
@@ -6,8 +6,8 @@
 
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.22
-coverage==5.0.4
+codecov==2.1.0
+coverage==5.1
 idna==2.9                 # via requests
 requests==2.23.0          # via codecov
 urllib3==1.25.8           # via requests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,7 +7,7 @@
 attrs==19.3.0             # via pytest
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-coverage==5.0.4           # via pytest-cov
+coverage==5.1             # via pytest-cov
 factory-boy==2.12.0
 faker==4.0.2              # via factory-boy
 freezegun==0.3.15


### PR DESCRIPTION
Update codecov to 2.1.0 to fix an issue in uploading coverage data to
codecov.io.  Check [1] for details about why this upgrade is needed.

Also update the coverage package to latest version.

[1] https://community.codecov.io/t/http-400-while-uploading-to-s3-with-python-codecov-from-travis/1428/7