### PR TITLE
Dashboard: use env variable for map centre coordinates

### DIFF
--- a/dashboard/src/config.ts
+++ b/dashboard/src/config.ts
@@ -1,6 +1,17 @@
+import { Point } from './components/types';
+
 export const isDev: boolean = (process.env.NODE_ENV === 'development');
 
 export const apiBaseUrl: string = process.env.REACT_APP_API_URL || (
     (isDev)
         ? 'http://localhost:8000/'
         : 'https://api.parkkiopas.fi/');
+
+let mapPoint: Point;
+if (typeof process.env.REACT_APP_API_CENTER !== 'undefined') {
+    const envPoint = process.env.REACT_APP_API_CENTER!.split(',').map(Number);
+    mapPoint = [envPoint[0], envPoint[1]];
+} else {
+    mapPoint = [60.17, 24.94]; // Default to Helsinki centrum
+}
+export const centerCoordinates: Point = mapPoint;

--- a/dashboard/src/reducers.ts
+++ b/dashboard/src/reducers.ts
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import { combineReducers } from 'redux';
 
 import { Action } from './actions';
+import { centerCoordinates } from './config';
 import * as conv from './converters';
 import {
     AuthenticationState, ParkingRegionMapState, ParkingsMap, RegionsMap,
@@ -85,7 +86,7 @@ function auth(
 
 const initialParkingRegionMapState: ParkingRegionMapState = {
     bounds: undefined,
-    center: [60.17, 24.94],
+    center: centerCoordinates,
     zoom: 12,
 };
 


### PR DESCRIPTION
Add an option to use an env variable for map centre coordinates. Use the original coordinates as default if env variable is not set.