### PR TITLE
Fix pagination of valid_permit_item endpoint in Enforcement API

### DIFF
--- a/docs/api/enforcement.yaml
+++ b/docs/api/enforcement.yaml
@@ -503,8 +503,15 @@ paths:
                     - << : *validPermitItemExample
                       area: "B"
                       registration_number: "XYZ-456"
-                properties:
-                  << : *paginatedResult
+                properties: &cursorPaginatedResult
+                  next:
+                    description: Link to the next result page
+                    type: string
+                    format: uri
+                  previous:
+                    description: Link to the previous result page
+                    type: string
+                    format: uri
                   results:
                     type: array
                     items:

--- a/docs/api/enforcement.yaml
+++ b/docs/api/enforcement.yaml
@@ -9,7 +9,7 @@ info:
     **Note**: This is a review version of the API specification.  The
     specification contains some parts that are not yet frozen and their
     contents might change before the final non-review version.
-  version: "1.2.0.rc3.2020-05-18"  # remove above warning when releasing 1.2.0
+  version: "1.2.0.rc4.2020-08-06"  # remove above warning when releasing 1.2.0
 servers:
   - url: https://api.parkkiopas.fi/enforcement/v1/
     description: Production server

--- a/docs/api/enforcement.yaml
+++ b/docs/api/enforcement.yaml
@@ -467,8 +467,7 @@ paths:
         - name: time
           in: query
           description: >-
-            Time when returned permit items should be valid. Required if no
-            registration number is set.
+            Time when returned permit items should be valid.
           schema:
             type: string
             format: date-time
@@ -476,7 +475,6 @@ paths:
           in: query
           description: >-
             Registration number of permit items. Dashes are ignored.
-            Required if no time is set.
           schema:
             type: string
       responses:

--- a/docs/api/enforcement.yaml
+++ b/docs/api/enforcement.yaml
@@ -162,6 +162,8 @@ components:
     ValidPermitItem:
       type: object
       example: &validPermitItemExample
+        id: 12432
+        permit_id: 4992
         area: "B"
         registration_number: "ABC-123"
         start_time: "2019-12-31T21:00:00Z"
@@ -169,6 +171,12 @@ components:
         operator: "63f8374e-1eed-44fa-9224-4cd0c64ddf35"
         operator_name: "Foobar Parkings"
       properties:
+        id:
+          description: Id of the permit item
+          type: integer
+        permit_id:
+          description: Id of the permit containing this item
+          type: integer
         area:
           description: Code of the permit area that this item permits parking to
           type: string

--- a/parkings/api/enforcement/valid_permit_item.py
+++ b/parkings/api/enforcement/valid_permit_item.py
@@ -52,4 +52,5 @@ class ValidPermitItemViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = CursorPagination
 
     def get_queryset(self):
-        return super().get_queryset().filter(permit__domain=self.request.user.enforcer.enforced_domain)
+        domain = self.request.user.enforcer.enforced_domain
+        return super().get_queryset().filter(permit__domain=domain)

--- a/parkings/api/enforcement/valid_permit_item.py
+++ b/parkings/api/enforcement/valid_permit_item.py
@@ -8,6 +8,7 @@ from .permissions import IsEnforcer
 
 
 class ValidPermitItemSerializer(serializers.ModelSerializer):
+    permit_id = serializers.IntegerField(source='permit.id')
     area = serializers.SlugRelatedField(slug_field='identifier', queryset=PermitArea.objects.all())
     operator = serializers.CharField(source='permit.series.owner.operator.id')
     operator_name = serializers.CharField(source='permit.series.owner.operator.name')
@@ -15,6 +16,8 @@ class ValidPermitItemSerializer(serializers.ModelSerializer):
     class Meta:
         model = PermitLookupItem
         fields = [
+            'id',
+            'permit_id',
             'area',
             'registration_number',
             'start_time',

--- a/parkings/api/enforcement/valid_permit_item.py
+++ b/parkings/api/enforcement/valid_permit_item.py
@@ -2,9 +2,8 @@ import django_filters
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, viewsets
 
-from parkings.models import PermitArea
-
-from ...models import PermitLookupItem
+from ...models import PermitArea, PermitLookupItem
+from ...pagination import CursorPagination
 from .permissions import IsEnforcer
 
 
@@ -51,9 +50,10 @@ class ValidPermitItemFilter(django_filters.rest_framework.FilterSet):
 
 class ValidPermitItemViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [IsEnforcer]
-    queryset = PermitLookupItem.objects.active().order_by('end_time')
+    queryset = PermitLookupItem.objects.active()
     serializer_class = ValidPermitItemSerializer
     filterset_class = ValidPermitItemFilter
+    pagination_class = CursorPagination
 
     def get_queryset(self):
         return super().get_queryset().filter(permit__domain=self.request.user.enforcer.enforced_domain)

--- a/parkings/api/enforcement/valid_permit_item.py
+++ b/parkings/api/enforcement/valid_permit_item.py
@@ -34,13 +34,6 @@ class ValidPermitItemFilter(django_filters.rest_framework.FilterSet):
         model = PermitLookupItem
         fields = []
 
-    def is_valid(self):
-        super(ValidPermitItemFilter, self).is_valid()
-        if not self.request.query_params.get("reg_num") and not self.request.query_params.get("time"):
-            raise serializers.ValidationError(_("Either time or registration number required."))
-        else:
-            return True
-
     def filter_reg_num(self, queryset, name, value):
         return queryset.by_subject(value)
 

--- a/parkings/pagination.py
+++ b/parkings/pagination.py
@@ -1,5 +1,12 @@
-from rest_framework.pagination import PageNumberPagination
+from rest_framework import pagination
 
 
-class Pagination(PageNumberPagination):
+class Pagination(pagination.PageNumberPagination):
     page_size_query_param = 'page_size'
+
+
+class CursorPagination(pagination.CursorPagination):
+    ordering = '-id'
+    page_size = 200
+    page_size_query_param = 'page_size'
+    max_page_size = 1000

--- a/parkings/tests/api/enforcement/test_valid_permit_item.py
+++ b/parkings/tests/api/enforcement/test_valid_permit_item.py
@@ -90,13 +90,21 @@ def test_list_endpoint_data(enforcer_api_client, enforcer, operator_factory):
 
 
 def check_permit_item_data_keys(permit_item_data):
-    permit_item_data_keys = {
-        'area', 'registration_number', 'start_time', 'end_time', 'operator', 'operator_name',
+    assert set(permit_item_data.keys()) == {
+        'id',
+        'permit_id',
+        'area',
+        'registration_number',
+        'start_time',
+        'end_time',
+        'operator',
+        'operator_name',
     }
-    assert set(permit_item_data.keys()) == permit_item_data_keys
 
 
 def check_permit_item_data_matches_permitlookuptem_object(permit_item_data, permit_item):
+    assert permit_item_data['id'] == permit_item.id
+    assert permit_item_data['permit_id'] == permit_item.permit.id
     assert permit_item_data['area'] == permit_item.area.identifier
     assert permit_item_data['registration_number'] == permit_item.registration_number
     assert permit_item_data['start_time'] == iso8601(permit_item.start_time)

--- a/parkings/tests/api/enforcement/test_valid_permit_item.py
+++ b/parkings/tests/api/enforcement/test_valid_permit_item.py
@@ -4,7 +4,7 @@ import pytest
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.status import (
-    HTTP_400_BAD_REQUEST, HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN)
+    HTTP_200_OK, HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN)
 
 from parkings.factories.permit import create_permit, create_permits
 from parkings.models import PermitLookupItem
@@ -64,11 +64,10 @@ def test_disallowed_methods(enforcer_api_client, enforcer, url_kind):
         enforcer_api_client, [url], disallowed_methods, 405)
 
 
-def test_reg_num_or_time_is_required(enforcer_api_client):
+def test_reg_num_and_time_are_optional(enforcer_api_client):
     response = enforcer_api_client.get(list_url)
-    error_message = 'Either time or registration number required.'
-    assert response.status_code == HTTP_400_BAD_REQUEST
-    assert error_message in response.data
+    assert response.status_code == HTTP_200_OK
+    assert response.data == {'next': None, 'previous': None, 'results': []}
 
 
 def test_list_endpoint_base_fields(enforcer_api_client):

--- a/parkings/tests/api/utils.py
+++ b/parkings/tests/api/utils.py
@@ -64,6 +64,10 @@ def check_list_endpoint_base_fields(data):
     assert set(data.keys()) == {'next', 'previous', 'count', 'results'}
 
 
+def check_cursor_list_endpoint_base_fields(data):
+    assert set(data.keys()) == {'next', 'previous', 'results'}
+
+
 def check_required_fields(api_client, url, expected_required_fields, detail_endpoint=False):
     method = put if detail_endpoint else post
 


### PR DESCRIPTION
The pagination of valid_permit_item endpoint in the Enforcement API
didn't work correctly.  When querying all the pages, the results didn't
always contain all items, but some items "between" the pages were
excluded.  Fix this issue by switching to cursor pagination ordered by
the id field (which is always increasing).

Also improve a few related things:

  * Add id and permit_id to the result so that it's easier to verify
    that all is there.

  * Relax the required parameters, because it is no longer needed to
    have the time parameter for pagination.

  * Minor improvement to code readability in get_queryset.