### PR TITLE
Dockerfile: Use python:3.7-slim-buster as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim as appbase
+FROM python:3.7-slim-buster as appbase
 
 ENV PYTHONBUFFERED 1
 


### PR DESCRIPTION
Change Dockerfile to use Docker image python:3.7-slim-buster which uses
Debian 10 (buster). Previously python:3.7-slim was used which used
Debian 11 (bullseye).

The used GDAL version gets downgraded from 3.2.2 to 2.4.0 which can be
checked by running "docker-compose exec api gdalinfo --version".

It seems there was an incompatibility with GDAL 3.2.2 and Django 2.2
which caused the test test_fill_parking_regions_mgmt_cmd in
parkings/tests/test_fill_parking_regions_command.py to fail.
By downgrading from GDAL 3.2.2 to 2.4.0 this test passes.

Fixes #218