### PR TITLE
Expose Docker db service's port 5432 to 127.0.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       POSTGRES_USER: parkkihubi
     volumes:
       - db_data:/var/lib/postgresql/data
+    ports:
+      - "127.0.0.1:5432:5432"
   api:
     build:
       context: "."


### PR DESCRIPTION
Change to docker-compose.yml:
 - Expose PostgreSQL's default port 5432 as port 5432 to 127.0.0.1 to
   enable access to the database from outside the Docker container.

This can be useful e.g. in development.