### PR TITLE
Implement parkings data export capability

### DIFF
--- a/dashboard/src/actions.ts
+++ b/dashboard/src/actions.ts
@@ -1,6 +1,6 @@
 import { Moment } from 'moment';
 
-import { ParkingList, RegionList, RegionStatsList } from './api/types';
+import { ParkingList, RegionList, RegionStatsList, PaymentZoneList, OperatorList } from './api/types';
 import { MapViewport } from './components/types';
 
 interface CheckExistingLoginAction {
@@ -139,6 +139,39 @@ export function receiveValidParkings(
     return {type: 'RECEIVE_VALID_PARKINGS', data, time};
 }
 
+interface ReceiveCsvAction {
+    type: 'RECEIVE_CSV';
+    data: string;
+}
+
+export function receiveCSV(
+    data: string
+): ReceiveCsvAction {
+    return {type: 'RECEIVE_CSV', data}
+}
+
+interface ReceiveOperatorsAction {
+    type: 'RECEIVE_OPERATORS';
+    data: OperatorList;
+}
+
+export function receiveOperators(
+    data: OperatorList
+): ReceiveOperatorsAction {
+    return {type: 'RECEIVE_OPERATORS', data}
+}
+
+interface ReceivePaymentZonesAction {
+    type: 'RECEIVE_PAYMENT_ZONES';
+    data: PaymentZoneList;
+}
+
+export function receivePaymentZones(
+    data: PaymentZoneList
+): ReceivePaymentZonesAction {
+    return {type: 'RECEIVE_PAYMENT_ZONES', data}
+}
+
 export type Action =
     CheckExistingLoginAction |
     ResolveExistingLoginCheckAction |
@@ -155,4 +188,7 @@ export type Action =
     SetSelectedRegionAction |
     ReceiveRegionStatsAction |
     ReceiveRegionInfoAction |
-    ReceiveValidParkingsAction;
+    ReceiveValidParkingsAction |
+    ReceiveOperatorsAction |
+    ReceivePaymentZonesAction |
+    ReceiveCsvAction;

--- a/dashboard/src/api/types.ts
+++ b/dashboard/src/api/types.ts
@@ -90,3 +90,33 @@ export interface ParkingProperties {
     created_at: string;
     modified_at: string;
 }
+
+
+export interface Operator {
+    id: string;
+    name?: string;
+    created_at?: string;
+    modified_at?: string;
+}
+
+export interface OperatorList extends PaginatedList {
+    results: Operator[];
+}
+
+export interface PaymentZone {
+    code: string;
+    name?: string;
+    domain?: string;
+}
+
+export interface PaymentZoneList extends PaginatedList {
+    results: PaymentZone[];
+}
+
+export interface ExportFilters {
+    operators?: string[];
+    payment_zones?: string[];
+    parking_check?: boolean;
+    time_start: string;
+    time_end: string;
+}

--- a/dashboard/src/api/utils.ts
+++ b/dashboard/src/api/utils.ts
@@ -1,0 +1,16 @@
+export function download(data: string, fileName: string): void {
+    const blob: Blob = new Blob([data], { type: 'text/csv' });
+    const blobURL: string = window.URL.createObjectURL(blob)
+
+    const downloadLink: HTMLAnchorElement = document.createElement('a');
+    downloadLink.style.display = 'none';
+    downloadLink.href = blobURL;
+    downloadLink.setAttribute('download', fileName);
+
+    document.body.appendChild(downloadLink);
+    downloadLink.click();
+    setTimeout(function() {
+        document.body.removeChild(downloadLink);
+        window.URL.revokeObjectURL(blobURL);
+    }, 200)
+}

--- a/dashboard/src/components/Export.css
+++ b/dashboard/src/components/Export.css
@@ -1,0 +1,91 @@
+i {
+    margin-right: 3px !important;
+}
+
+.filter-card {
+    display: table !important;
+    width: 100% !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important
+}
+
+.row {
+    display: table !important;
+    width: 100% !important;
+    margin-left: 0 !important;
+    flex: 1 !important;
+    box-sizing: border-box;
+}
+
+.export-button {
+    color: #515455 !important;
+    box-shadow: none !important;
+    background: hsl(32, 39%, 81%) !important;
+    border-color: #e1cfbb !important;
+    margin-top: 4px;
+}
+
+.export-button:hover {
+    background: #f0e5dd !important;
+    border-color: #f0e5dd !important;
+}
+
+.download-button {
+    color: #515455 !important;
+    box-shadow: none !important;
+    background: #e1cfbb !important;
+    border-color: #e1cfbb !important;
+    float: right;
+    margin-right: 4px;
+}
+
+.download-button:hover {
+    background: #f0e5dd !important;
+    border-color: #f0e5dd !important;
+}
+
+.filter-field {
+    display: table-cell !important;
+    padding: 5px !important;
+}
+
+.multi-select-field {
+    width: 50% !important;
+}
+
+.datepicker-field {
+    width: 160px !important;
+}
+
+.parking-check-button {
+    color: #515455 !important;
+    box-shadow: none !important;
+    background: #f0e5dd !important;
+    border-color: #e1cfbb !important;
+}
+
+.parking-check-button:hover {
+    background: #e1cfbb !important;
+    border-color: #f0e5dd !important;
+}
+
+.parking-check-active {
+    background: #e1cfbb !important;
+}
+
+@media screen and (max-width: 28rem) {
+    .export-button .text {
+        display: none;
+        margin-right: auto !important;
+    }
+
+    .download-button .text {
+        display: none;
+        margin-right: auto !important;
+    }
+
+    .parking-check-button .text {
+        display: none;
+        margin-right: auto !important;
+    }
+}

--- a/dashboard/src/components/Export.tsx
+++ b/dashboard/src/components/Export.tsx
@@ -1,0 +1,180 @@
+import DateTime from "react-datetime";
+import Select from "react-select";
+import moment, { Moment } from "moment";
+import { Component } from "react";
+import { Button } from "reactstrap";
+import { ExportFilters } from "../api/types";
+import { Operators, PaymentZones } from "../types";
+
+import "./Export.css";
+
+type Option = {
+    value: string;
+    label: string;
+};
+
+interface State {
+    operatorSelections: string[];
+    paymentZoneSelections: string[];
+    startTime: Moment;
+    endTime: Moment;
+    parking_check: boolean;
+    showOptions: boolean;
+}
+
+export interface Props {
+    operators: Operators,
+    paymentZones: PaymentZones,
+    downloadCSV?: (filters: ExportFilters) => void;
+}
+
+const initialState: State = {
+    showOptions: false,
+    operatorSelections: [],
+    paymentZoneSelections: [],
+    startTime: moment().subtract(30, 'days'),
+    endTime: moment(),
+    parking_check: false,
+}
+
+class Export extends Component<Props, State> {
+    constructor(props: Props) {
+        super(props);
+        this.state = initialState;
+    }
+
+    handleExportButtonClick = () => {
+        this.setState((prevState) => ({...initialState, showOptions: !prevState.showOptions}));
+    }
+
+    handleDownloadClick = () => {
+        if (this.props.downloadCSV) {
+            const filters: ExportFilters = {
+                ...(this.state.operatorSelections.length && { operators: this.state.operatorSelections }),
+                ...(this.state.paymentZoneSelections.length && { payment_zones: this.state.paymentZoneSelections }),
+                time_start: this.state.startTime.format("DD.MM.YYYY HH.mm"),
+                time_end: this.state.endTime.format("DD.MM.YYYY HH.mm"),
+                parking_check: this.state.parking_check,
+            };
+
+            this.props.downloadCSV(filters);
+        }
+    };
+
+    handleDateChange = (time: moment.Moment | string, name: string) => {
+        this.setState({
+            [name]: moment(time)
+        } as any);
+    };
+
+    handleOperatorSelect = (options: Option[]) => {
+        this.setState({
+            operatorSelections: options.map((option) => option.value),
+        });
+    };
+
+    handlePaymentZoneSelect = (options: Option[]) => {
+        this.setState({
+            paymentZoneSelections: options.map((option) => option.value),
+        });
+    };
+
+    handleCheckParkingCheckBoxChange = () => {
+        this.setState((prevState) => ({
+            parking_check: !prevState.parking_check,
+        }));
+    };
+
+    render() {
+        const {
+            operators,
+            paymentZones
+        } = this.props;
+        const operatorOptions = Object.keys(operators).map((k) => ({value: operators[k].id, label: operators[k].name}));
+        const paymentZoneOptions = Object.keys(paymentZones).map((k) => ({value: paymentZones[k].code, label: paymentZones[k].name}));
+
+        return (
+            <>
+                <Button
+                    className="export-button"
+                    color="info"
+                    outline={true}
+                    onClick={this.handleExportButtonClick}
+                >
+                    <i className="fa fa-share"></i>
+                    <span className="text">Vie</span>
+                </Button>
+                {this.state.showOptions === true ? (
+                    <div className="filter-card">
+                        <div className="row">
+                            <Select
+                                isMulti={true}
+                                options={operatorOptions}
+                                className="filter-field multi-select-field"
+                                onChange={(option) =>
+                                    this.handleOperatorSelect(option as Option[])
+                                }
+                                placeholder="Valitse operaattori"
+                            />
+                            <Select
+                                isMulti={true}
+                                options={paymentZoneOptions}
+                                className="filter-field multi-select-field"
+                                onChange={(option) =>
+                                    this.handlePaymentZoneSelect(option as Option[])
+                                }
+                                placeholder="Valitse maksuvyöhyke"
+                            />
+                        </div>
+                        <div className="row">
+                            <DateTime
+                                dateFormat="DD.MM.YYYY"
+                                timeFormat="HH.mm"
+                                className="filter-field datepicker-field"
+                                onChange={(moment) =>
+                                    this.handleDateChange(moment, "startTime")
+                                }
+                                initialValue={this.state.startTime}
+                                inputProps={{readOnly: true}}
+                            />
+                            <DateTime
+                                dateFormat="DD.MM.YYYY"
+                                timeFormat="HH.mm"
+                                className="filter-field datepicker-field"
+                                onChange={(moment) =>
+                                    this.handleDateChange(moment, "endTime")
+                                }
+                                initialValue={this.state.endTime}
+                                inputProps={{readOnly: true}}
+                            />
+                            <Button
+                                className={
+                                    this.state.parking_check === true 
+                                    ? "filter-field parking-check-button parking-check-active"
+                                    : "filter-field parking-check-button"
+                                }
+                                color="info"
+                                outline={true}
+                                onClick={this.handleCheckParkingCheckBoxChange}
+                            >
+                                <i className="fa fa-check-circle" />
+                                <span className="text">Tarkistettu</span>
+                            </Button>
+                            <Button
+                                className="filter-field download-button"
+                                color="info"
+                                outline={true}
+                                onClick={this.handleDownloadClick}
+                            >
+                                <i className="fa fa-download" />
+                                <span className="text">Lataa</span>
+                            </Button>
+                        </div>
+                    </div>
+                ) : null}
+            </>
+        );
+    }
+}
+
+export default Export;

--- a/dashboard/src/containers/Dashboard.tsx
+++ b/dashboard/src/containers/Dashboard.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 
 import { Button } from 'reactstrap';
 
+import Export from './Export';
 import RegionSelector from './RegionSelector';
 import * as dispatchers from '../dispatchers';
 import { RootState } from '../types';
@@ -14,6 +15,7 @@ import LastParkingsTable from './LastParkingsTable';
 
 interface Props {
     autoUpdate?: boolean;
+    onMount?: () => void;
     onUpdate?: () => void;
     onLogout?: () => void;
 }
@@ -25,6 +27,9 @@ class Dashboard extends Component<Props> {
     timerInterval: number = 1000; // 1 second
 
     componentDidMount() {
+      if(this.props.onMount) {
+        this.props.onMount();
+      }
       if (this.props.autoUpdate && !this.timer) {
         this.enableAutoUpdate();
       }
@@ -82,6 +87,7 @@ class Dashboard extends Component<Props> {
             <div className="d-flex">
                 <div className="table-card">
                     <TimeSelect />
+                    <Export />
                     <div className="margin-bottom-8" />
                     <LastParkingsTable />
                 </div>
@@ -104,6 +110,7 @@ const mapStateToProps = (state: RootState): Props => ({
 });
 
 const mapDispatchToProps = (dispatch: any): Props => ({
+  onMount: () => dispatch(dispatchers.fetchData()),
   onUpdate: () => dispatch(dispatchers.updateData()),
   onLogout: () => dispatch(dispatchers.logout()),
 });

--- a/dashboard/src/containers/Export.ts
+++ b/dashboard/src/containers/Export.ts
@@ -1,0 +1,19 @@
+import { connect } from 'react-redux';
+
+import { RootState } from '../types';
+import { ExportFilters } from '../api/types'
+import Export, { Props } from '../components/Export';
+import * as dispatchers from '../dispatchers';
+
+function mapStateToProps(state: RootState): Props {
+	return {
+		operators: state.operators,
+		paymentZones: state.paymentZones,
+	};
+}
+
+const mapDispatchToProps = (dispatch: any) => ({
+	downloadCSV: (filters: ExportFilters) => dispatch(dispatchers.downloadCSV(filters)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Export);

--- a/dashboard/src/converters.ts
+++ b/dashboard/src/converters.ts
@@ -30,6 +30,20 @@ export function convertRegionStats(
     };
 }
 
+export function convertOperator(operator: api.Operator): ui.Operator {
+    return {
+        id: operator.id,
+        name: operator.name!,
+    }
+}
+
+export function convertPaymentZone(paymentZone: api.PaymentZone): ui.PaymentZone {
+    return {
+        code: paymentZone.code,
+        name: paymentZone.name!,
+    }
+}
+
 export function convertParking(parking: api.Parking): ui.Parking {
     const props = parking.properties;
     return {

--- a/dashboard/src/dispatchers.ts
+++ b/dashboard/src/dispatchers.ts
@@ -5,6 +5,7 @@ import * as actions from './actions';
 import { Action } from './actions';
 import api from './api';
 import { MapViewport } from './components/types';
+import { ExportFilters } from './api/types';
 import { RootState } from './types';
 
 const updateInterval = 5 * 60 * 1000;  // 5 minutes in ms
@@ -91,6 +92,13 @@ export function setDataTime(time?: moment.Moment) {
   };
 }
 
+export function fetchData() {
+  return (dispatch: Dispatch<any>) => {
+    dispatch(fetchOperators());
+    dispatch(fetchPaymentZones());
+  };
+}
+
 function fetchMissingData(time: moment.Moment) {
   return (dispatch: Dispatch<any>, getState: () => RootState) => {
     const timestamp = time.valueOf();
@@ -161,6 +169,43 @@ export function fetchValidParkings(time: moment.Moment) {
         },
         (error) => {
           alert('Valid parkings fetch failed: ' + error);
+        });
+  };
+}
+
+export function downloadCSV(filters: ExportFilters) {
+  return (dispatch: Dispatch<Action>) => {
+    api.downloadCSV(
+        filters,
+        (response) => {
+          dispatch(actions.receiveCSV(response.data));
+        },
+        (error) => {
+          alert('CSV download failed: ' + error);
+        });
+  };
+}
+
+export function fetchOperators() {
+  return (dispatch: Dispatch<Action>) => {
+    api.fetchOperators(
+        (response) => {
+          dispatch(actions.receiveOperators(response.data));
+        },
+        (error) => {
+          alert('Operator fetch failed: ' + error);
+        });
+  };
+}
+
+export function fetchPaymentZones() {
+  return (dispatch: Dispatch<Action>) => {
+    api.fetchPaymentZones(
+        (response) => {
+          dispatch(actions.receivePaymentZones(response.data));
+        },
+        (error) => {
+          alert('Payment zone fetch failed: ' + error);
         });
   };
 }

--- a/dashboard/src/reducers.ts
+++ b/dashboard/src/reducers.ts
@@ -6,7 +6,7 @@ import { centerCoordinates } from './config';
 import * as conv from './converters';
 import {
     AuthenticationState, ParkingRegionMapState, ParkingsMap, RegionsMap,
-    RegionUsageHistory, ValidParkingsHistory,
+    RegionUsageHistory, ValidParkingsHistory, PaymentZones, Operators,
     ViewState } from './types';
 
 // Auth state reducer ////////////////////////////////////////////////
@@ -151,6 +151,22 @@ function parkings(state: ParkingsMap = {}, action: Action): ParkingsMap {
     return state;
 }
 
+function operators(state: any = {}, action: Action): Operators {
+    if (action.type === 'RECEIVE_OPERATORS') {
+        const newOperators = mapByIdAndApply(action.data.results, conv.convertOperator as any);
+        return {...state, ...newOperators } as Operators;
+    }
+    return state;
+}
+
+function paymentZones(state: any = {}, action: Action): PaymentZones {
+    if (action.type === 'RECEIVE_PAYMENT_ZONES') {
+        const newPaymentZones = _.assign({}, ...action.data.results.map((item: any) => ({[item.code]: conv.convertPaymentZone(item)})));
+        return {...state, ...newPaymentZones} as PaymentZones;
+    }
+    return state;
+}
+
 function regionUsageHistory(
     state: RegionUsageHistory = {},
     action: Action
@@ -202,6 +218,8 @@ const rootReducer  = () => combineReducers({
         parkings,
         regionUsageHistory,
         validParkingsHistory,
+        operators,
+        paymentZones,
     });
 
 export default rootReducer;

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -19,6 +19,9 @@ export interface RootState {
 
     parkings: ParkingsMap;
 
+    operators: Operators;
+    paymentZones: PaymentZones;
+
     regionUsageHistory: RegionUsageHistory;
     validParkingsHistory: ValidParkingsHistory;
 }
@@ -84,4 +87,22 @@ export interface RegionUsageInfo {
 
 export interface ValidParkingsHistory {
     [time: number]: ParkingId[];
+}
+
+export interface Operator {
+    id: string;
+    name: string;
+}
+
+export interface PaymentZone {
+    code: string;
+    name: string;
+}
+
+export interface Operators {
+    [key: string]: Operator
+}
+
+export interface PaymentZones {
+    [key: string]: PaymentZone
 }

--- a/parkings/api/monitoring/export_parkings.py
+++ b/parkings/api/monitoring/export_parkings.py
@@ -1,0 +1,112 @@
+import csv
+
+from rest_framework import renderers, serializers, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from six import StringIO
+
+from ...models import Parking, ParkingCheck
+from .permissions import IsMonitor
+
+
+class CSVRenderer(renderers.BaseRenderer):
+    media_type = "text/csv"
+    format = "csv"
+    render_style = 'binary'
+
+    def render(self, filters, media_type=None, renderer_context=None):
+        time_start = filters["time_start"]
+        time_end = filters["time_end"]
+        operators = filters.get("operators")
+        payment_zones = filters.get("payment_zones")
+        parking_check = filters.get("parking_check")
+
+        kwargs = {
+            "time_start__lte": time_end,
+            "time_end__gte": time_start,
+        }
+
+        if payment_zones:
+            kwargs["zone__code__in"] = payment_zones
+        if operators:
+            kwargs["operator__id__in"] = operators
+
+        parkings = (
+            Parking.objects
+            .filter(**kwargs)
+            .order_by("-time_start")
+            .prefetch_related("operator", "zone")
+        )
+
+        if parking_check:
+            parking_check_parking_ids = (
+                ParkingCheck.objects
+                .filter(found_parking__id__in=parkings)
+                .order_by("found_parking")
+                .values_list("found_parking")
+                .distinct()
+            )
+            parkings = parkings.filter(id__in=parking_check_parking_ids)
+
+        buffer = StringIO()
+        writer = csv.writer(buffer)
+
+        for park in parkings:
+            writer.writerow([
+                ("%s, %s" % (park.location.x, park.location.y)) if park.location else " ",
+                park.terminal_number,
+                park.time_start.strftime("%d.%m.%Y %H.%M"),
+                park.time_end.strftime("%d.%m.%Y %H.%M"),
+                park.created_at.strftime("%d.%m.%Y %H.%M"),
+                park.modified_at.strftime("%d.%m.%Y %H.%M"),
+                park.operator.name,
+                park.zone.name
+            ])
+
+        return buffer.getvalue()
+
+
+class ExportFilterSerializer(serializers.Serializer):
+    operators = serializers.ListSerializer(child=serializers.CharField(), required=False)
+    payment_zones = serializers.ListSerializer(child=serializers.CharField(), required=False)
+    parking_check = serializers.BooleanField(required=False)
+    time_start = serializers.DateTimeField(
+        input_formats=["%d.%m.%Y %H.%M"],
+    )
+    time_end = serializers.DateTimeField(
+        input_formats=["%d.%m.%Y %H.%M"],
+    )
+
+    def validate(self, data):
+        time_start = data.get("time_start")
+        time_end = data.get("time_end")
+
+        if not time_start or not time_end:
+            raise serializers.ValidationError("You must provde start date and end date")
+        elif time_start > time_end:
+            raise serializers.ValidationError("End date must be after start date.")
+
+        return data
+
+
+class ExportViewSet(viewsets.ViewSet):
+    queryset = Parking.objects.all()
+    permission_classes = [IsMonitor, ]
+
+    @action(detail=False, methods=['post'], renderer_classes=[CSVRenderer])
+    def download(self, request):
+        serializer = ExportFilterSerializer(data=request.data)
+        if serializer.is_valid(raise_exception=True):
+            time_start = serializer.validated_data["time_start"]
+            time_end = serializer.validated_data["time_end"]
+            file_name = "parkings_{}_{}.csv".format(
+                time_start.date(), time_end.date()
+            )
+            response = Response(
+                serializer.validated_data,
+                content_type="text/csv",
+                headers={"X-Suggested-Filename": file_name}
+            )
+            response['Content-Disposition'] = 'attachment; filename="%s"' % file_name
+
+            return response

--- a/parkings/api/monitoring/urls.py
+++ b/parkings/api/monitoring/urls.py
@@ -1,6 +1,7 @@
 from rest_framework.routers import DefaultRouter
 
 from ..url_utils import versioned_url
+from .export_parkings import ExportViewSet
 from .region import RegionViewSet
 from .region_statistics import RegionStatisticsViewSet
 from .valid_parking import ValidParkingViewSet
@@ -11,8 +12,11 @@ router.register(r'region_statistics', RegionStatisticsViewSet,
                 basename='regionstatistics')
 router.register(r'valid_parking', ValidParkingViewSet,
                 basename='valid_parking')
+router.register(r'export', ExportViewSet, basename="export")
+
 
 app_name = 'monitoring'
+
 urlpatterns = [
     versioned_url('v1', router.urls),
 ]

--- a/parkings/exception_handler.py
+++ b/parkings/exception_handler.py
@@ -1,7 +1,9 @@
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.views import exception_handler
+from rest_framework.renderers import JSONRenderer
 
 from parkings.api.common import ParkingException
+from parkings.api.monitoring.export_parkings import CSVRenderer
 
 
 def parkings_exception_handler(exc, context):
@@ -12,5 +14,8 @@ def parkings_exception_handler(exc, context):
             response.data['code'] = exc.get_codes()
         elif isinstance(exc, PermissionDenied):
             response.data['code'] = 'permission_denied'
+
+        if isinstance(context["request"].accepted_renderer, CSVRenderer):
+            context["request"].accepted_renderer = JSONRenderer()
 
     return response

--- a/parkings/tests/api/monitoring/test_parkings_export.py
+++ b/parkings/tests/api/monitoring/test_parkings_export.py
@@ -1,0 +1,275 @@
+import csv
+import datetime
+
+from django.urls import reverse
+from django.utils.timezone import utc
+from rest_framework import status
+from six import StringIO
+
+from parkings.factories import ParkingCheckFactory
+from parkings.factories.parking import create_payment_zone
+
+LOCATION = 0
+TERMINAL_NUMBER = 1
+TIME_START = 2
+TIME_END = 3
+CREATED_AT = 4
+MODIFIED_AT = 5
+OPERATOR = 6
+ZONE = 7
+
+export_url = reverse('monitoring:v1:export-download')
+
+
+def test_export_filtering_no_data_if_starts_before_range_and_ends_before_range(monitoring_api_client, parking_factory):
+    start = datetime.datetime(2018, 7, 6, 15, 15, tzinfo=utc)
+    end = datetime.datetime(2018, 7, 6, 18, 45, tzinfo=utc)
+    parking_factory(time_start=start, time_end=end)
+    data = {
+        "time_start": "05.07.2018 13.45",
+        "time_end": "06.07.2018 15.00",
+    }
+
+    result = monitoring_api_client.post(export_url, data=data)
+    assert result.status_code == status.HTTP_200_OK
+
+    # Data doesn't get rendered by the custom renderer in tests for whatever reason. So render it manually.
+    renderer = result.accepted_renderer
+    reader = csv.reader(StringIO(renderer.render(result.data)))
+
+    parking_row = None
+
+    for row in reader:
+        parking_row = row
+
+    assert parking_row is None
+
+
+def test_export_filtering_yes_data_if_starts_before_range_and_ends_in_range(monitoring_api_client, parking_factory):
+    start = datetime.datetime(2018, 7, 6, 15, 15, tzinfo=utc)
+    end = datetime.datetime(2018, 7, 6, 18, 45, tzinfo=utc)
+    parking_factory(time_start=start, time_end=end)
+    data = {
+        "time_start": "05.07.2018 13.45",
+        "time_end": "06.07.2018 15.15",
+    }
+
+    result = monitoring_api_client.post(export_url, data=data)
+    assert result.status_code == status.HTTP_200_OK
+
+    # Data doesn't get rendered by the custom renderer in tests for whatever reason. So render it manually.
+    renderer = result.accepted_renderer
+    reader = csv.reader(StringIO(renderer.render(result.data)))
+
+    parking_row = None
+
+    for row in reader:
+        parking_row = row
+
+    assert parking_row is not None
+
+
+def test_export_filtering_yes_data_if_starts_in_range_and_ends_in_range(monitoring_api_client, parking_factory):
+    start = datetime.datetime(2018, 7, 6, 15, 15, tzinfo=utc)
+    end = datetime.datetime(2018, 7, 6, 18, 45, tzinfo=utc)
+    parking_factory(time_start=start, time_end=end)
+    data = {
+        "time_start": "06.07.2018 15.45",
+        "time_end": "06.07.2018 18.00",
+    }
+
+    result = monitoring_api_client.post(export_url, data=data)
+    assert result.status_code == status.HTTP_200_OK
+
+    # Data doesn't get rendered by the custom renderer in tests for whatever reason. So render it manually.
+    renderer = result.accepted_renderer
+    reader = csv.reader(StringIO(renderer.render(result.data)))
+
+    parking_row = None
+
+    for row in reader:
+        parking_row = row
+
+    assert parking_row is not None
+
+
+def test_export_filtering_yes_data_if_starts_in_range_and_ends_after_range(monitoring_api_client, parking_factory):
+    start = datetime.datetime(2018, 7, 6, 15, 15, tzinfo=utc)
+    end = datetime.datetime(2018, 7, 6, 18, 45, tzinfo=utc)
+    parking_factory(time_start=start, time_end=end)
+    data = {
+        "time_start": "06.07.2018 15.45",
+        "time_end": "07.07.2018 18.00",
+    }
+
+    result = monitoring_api_client.post(export_url, data=data)
+    assert result.status_code == status.HTTP_200_OK
+
+    # Data doesn't get rendered by the custom renderer in tests for whatever reason. So render it manually.
+    renderer = result.accepted_renderer
+    reader = csv.reader(StringIO(renderer.render(result.data)))
+
+    parking_row = None
+
+    for row in reader:
+        parking_row = row
+
+    assert parking_row is not None
+
+
+def test_export_filtering_no_data_if_starts_after_range_and_ends_after_range(monitoring_api_client, parking_factory):
+    start = datetime.datetime(2018, 7, 6, 15, 15, tzinfo=utc)
+    end = datetime.datetime(2018, 7, 6, 18, 45, tzinfo=utc)
+    parking_factory(time_start=start, time_end=end)
+    data = {
+        "time_start": "07.07.2018 15.45",
+        "time_end": "08.07.2018 18.00",
+    }
+
+    result = monitoring_api_client.post(export_url, data=data)
+    assert result.status_code == status.HTTP_200_OK
+
+    # Data doesn't get rendered by the custom renderer in tests for whatever reason. So render it manually.
+    renderer = result.accepted_renderer
+    reader = csv.reader(StringIO(renderer.render(result.data)))
+
+    parking_row = None
+
+    for row in reader:
+        parking_row = row
+
+    assert parking_row is None
+
+
+def test_export_filtering_yes_data_if_starts_before_range_and_ends_after_range(monitoring_api_client, parking_factory):
+    start = datetime.datetime(2018, 7, 6, 15, 15, tzinfo=utc)
+    end = datetime.datetime(2018, 7, 6, 18, 45, tzinfo=utc)
+    parking_factory(time_start=start, time_end=end)
+    data = {
+        "time_start": "05.07.2018 15.45",
+        "time_end": "08.07.2018 18.00",
+    }
+
+    result = monitoring_api_client.post(export_url, data=data)
+    assert result.status_code == status.HTTP_200_OK
+
+    # Data doesn't get rendered by the custom renderer in tests for whatever reason. So render it manually.
+    renderer = result.accepted_renderer
+    reader = csv.reader(StringIO(renderer.render(result.data)))
+
+    parking_row = None
+
+    for row in reader:
+        parking_row = row
+
+    assert parking_row is not None
+
+
+def test_export_filtering_correct_data_no_parking_check(monitoring_api_client, parking_factory, operator_factory):
+    zone1 = create_payment_zone(code=1, name="MV1")
+    operator1 = operator_factory(name="op1")
+    start1 = datetime.datetime(2018, 7, 6, 15, 15, tzinfo=utc)
+    end1 = datetime.datetime(2018, 7, 6, 18, 45, tzinfo=utc)
+    parking_factory(
+        time_start=start1,
+        time_end=end1,
+        operator=operator1,
+        zone=zone1
+    )
+
+    zone2 = create_payment_zone(code=2, name="MV2")
+    operator2 = operator_factory(name="op2")
+    start2 = datetime.datetime(2018, 7, 6, 15, 15, tzinfo=utc)
+    end2 = datetime.datetime(2018, 7, 6, 18, 45, tzinfo=utc)
+    parking_factory(
+        time_start=start2,
+        time_end=end2,
+        operator=operator2,
+        zone=zone2
+    )
+
+    data = {
+        "time_start": "05.07.2018 15.45",
+        "time_end": "08.07.2018 18.00",
+        "payment_zones": [zone1.code],
+        "operators": [operator1.id],
+        "parking_check": False
+    }
+
+    result = monitoring_api_client.post(export_url, data=data)
+    assert result.status_code == status.HTTP_200_OK
+
+    # Data doesn't get rendered by the custom renderer in tests for whatever reason. So render it manually.
+    renderer = result.accepted_renderer
+    reader = csv.reader(StringIO(renderer.render(result.data)))
+
+    parking_row = None
+    row_count = 0
+
+    for row in reader:
+        parking_row = row
+        row_count += 1
+
+    assert parking_row is not None
+    assert parking_row[OPERATOR] == operator1.name
+    assert parking_row[ZONE] == zone1.name
+    assert row_count == 1
+
+
+def test_export_filtering_correct_data_with_parking_check(monitoring_api_client, parking_factory, operator_factory):
+    zone1 = create_payment_zone(code=1, name="MV1")
+    operator1 = operator_factory(name="op1")
+    start1 = datetime.datetime(2018, 7, 6, 15, 15, tzinfo=utc)
+    end1 = datetime.datetime(2018, 7, 6, 18, 45, tzinfo=utc)
+    parking_factory(
+        time_start=start1,
+        time_end=end1,
+        operator=operator1,
+        zone=zone1
+    )
+
+    zone2 = create_payment_zone(code=2, name="MV2")
+    operator2 = operator_factory(name="op2")
+    start2 = datetime.datetime(2018, 7, 6, 15, 15, tzinfo=utc)
+    end2 = datetime.datetime(2018, 7, 6, 18, 45, tzinfo=utc)
+    parking2 = parking_factory(
+        time_start=start2,
+        time_end=end2,
+        operator=operator2,
+        zone=zone2
+    )
+
+    ParkingCheckFactory(found_parking=parking2)
+
+    data = {
+        "time_start": "05.07.2018 15.45",
+        "time_end": "08.07.2018 18.00",
+        "payment_zones": [
+            zone1.code,
+            zone2.code,
+        ],
+        "operators": [
+            operator1.id,
+            operator2.id
+        ],
+        "parking_check": True
+    }
+
+    result = monitoring_api_client.post(export_url, data=data)
+    assert result.status_code == status.HTTP_200_OK
+
+    # Data doesn't get rendered by the custom renderer in tests for whatever reason. So render it manually.
+    renderer = result.accepted_renderer
+    reader = csv.reader(StringIO(renderer.render(result.data)))
+
+    parking_row = None
+    row_count = 0
+
+    for row in reader:
+        parking_row = row
+        row_count += 1
+
+    assert parking_row is not None
+    assert parking_row[OPERATOR] == operator2.name
+    assert parking_row[ZONE] == zone2.name
+    assert row_count == 1

--- a/parkkihubi/settings.py
+++ b/parkkihubi/settings.py
@@ -200,6 +200,9 @@ JWT2FA_AUTH = {
 }
 
 CORS_ORIGIN_ALLOW_ALL = True
+CORS_EXPOSE_HEADERS = [
+    "X-Suggested-Filename", # Custom header for export CSV file name
+]
 
 ##############
 # Parkkihubi #


### PR DESCRIPTION
### Export button to toggle options rendering
![image](https://user-images.githubusercontent.com/31072611/166199087-ffee66a6-1fbe-4b54-b511-97f6c47d95ef.png)
______________
### Nothing selected, start & end time automatically set. 
![image](https://user-images.githubusercontent.com/31072611/166199202-f99cf652-ac55-4ecc-9cf4-d048b25716ea.png)
______________
### Filters selected
![image](https://user-images.githubusercontent.com/31072611/166199370-8472eca2-d916-4a81-98a8-468d54e28e83.png)
______________
### CSV file
![image](https://user-images.githubusercontent.com/31072611/166199555-4aaf698f-b372-45a0-88b2-7717c583ce50.png)
______________

### Task requirements:
Export parkings data to CSV file.
* Fields included in CSV must be: Location coordinates, terminal number, start time, end time, created at -time, modified at -time, operator, payment zone.
* User may filter data to be exported with: operator(multi select), payment zone(multi slect), time range (start & end), parking checked.
* For now, filter by activity in time range. So if parking was active anytime **within** the time range.

### Comments
> One main complaint is the UX when downloading. In a case where the user filtered for >100k parking objects, it will take a long time for the server to respond, because iterating over so many objects takes a long time. So after clicking the download button, users can expect a waiting time of 10's of seconds of nothing happening (and hope the user doesn't click the download button multiple times because they are confused why nothing his happening). Also to mention that the RAM usage of the server may also suffer since there are so many parking objects.