### PR TITLE
Add VSCode/Codium settings and configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,43 @@
+{
+    "configurations": [
+        {
+            "name": "Python: Django (locally)",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/manage.py",
+            "args": ["runserver"],
+            "django": true,
+            "justMyCode": false
+        },
+        {
+            "name": "Python: Attach to docker container",
+            "type": "python",
+            "request": "attach",
+            "connect": {"host": "localhost", "port": 5678},
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "/app"
+                }
+            ],
+            "justMyCode": false
+        },
+        {
+            "name": "Docker: Python - Django",
+            "type": "docker",
+            "request": "launch",
+            "preLaunchTask": "docker-run: debug",
+            "python": {
+                "pathMappings": [
+                    {
+                        "localRoot": "${workspaceFolder}",
+                        "remoteRoot": "/app"
+                    }
+                ],
+                "projectType": "django",
+                "django": true,
+                "justMyCode": false
+            }
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "python.testing.pytestEnabled": true,
+    "python.testing.cwd": "${workspaceFolder}",
+    "python.testing.pytestPath": "${workspaceFolder}/run-pytest",
+    "python.testing.pytestArgs": [
+        "-vv",
+        // Uncomment --create-db to refresh test database (after model changes)
+        // "--create-db",
+    ],
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "docker-build",
+            "label": "docker-build",
+            "platform": "python",
+            "dockerBuild": {
+                "tag": "parkkihubi:latest",
+                "dockerfile": "${workspaceFolder}/Dockerfile",
+                "context": "${workspaceFolder}",
+                "target": "development",
+                "pull": true
+            }
+        },
+        {
+            "type": "docker-run",
+            "label": "docker-run: debug",
+            "dependsOn": [
+                "docker-build"
+            ],
+            "python": {
+                "args": [
+                    "runserver",
+                    "0.0.0.0:8000",
+                    "--nothreading",
+                    "--noreload"
+                ],
+                "file": "manage.py"
+            },
+            "dockerRun": {
+                "env": {
+                    "DEBUG": "1",
+                    "SECRET_KEY": "not-empty",
+                    "DATABASE_URL": "postgis://parkkihubi:parkkihubi@db/parkkihubi"
+                }
+            }
+        }
+    ]
+}

--- a/env.example
+++ b/env.example
@@ -1,0 +1,8 @@
+# .env file example.  Save as ".env" and modify to your needs.
+DEBUG=1
+#ALLOWED_HOSTS=*
+#SECRET_KEY=
+#VAR_ROOT=/home/user/projects/parkkihubi/var
+DATABASE_URL=postgis:///parkkihubi
+#TEST_DATABASE_TEMPLATE=template_gis
+USE_DOCKER=1

--- a/run-pytest
+++ b/run-pytest
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Run pytest locally or on docker-compose app service
+#
+# When using docker-compose app service, the options passed by VSCodium
+# will be handled specially to make its pytest integration smoother.
+#
+# To run pytest within docker, set USE_DOCKER environment variable to 1
+# or add USE_DOCKER=1 to the .env file.
+
+set -e
+
+USE_DOCKER=${USE_DOCKER}
+if [[ -z "$USE_DOCKER" ]] && [[ -e .env ]]; then
+    USE_DOCKER=$(sed -n '/^USE_DOCKER=/s/^[^=]*=//p' .env)
+fi
+
+if [[ "$USE_DOCKER" == "1" ]] || [[ "$USE_DOCKER" == "yes" ]]; then
+    docker-compose up -d
+else
+    exec pytest "$@"
+    exit $?
+fi
+
+unset xml_file
+opts=()
+while [[ $# -gt 0 ]]; do
+    opt="$1"
+    shift
+    if [[ "$opt" == "--rootdir" ]]; then  # Ignore rootdir option
+        shift  # Ignore also the argument to --rootdir
+        continue
+    elif [[ "$opt" == --junit-xml=* ]]; then  # Parse junit-xml option
+        xml_file=${opt#--junit-xml=}
+        opt="--junit-xml=/tmp/pytest_junit.xml"
+    fi
+    opts+=("$opt")
+done
+
+misc_opts=(
+    "-o" "cache_dir=/tmp/pytest_cache"
+)
+
+set +e
+docker-compose exec -T app pytest "${misc_opts[@]}" "${opts[@]}"
+exit_code=$?
+set -e
+
+if [[ -n "$xml_file" ]]; then
+    docker-compose exec -T app cat /tmp/pytest_junit.xml > "$xml_file"
+fi
+
+exit $exit_code

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,10 @@ norecursedirs = bower_components node_modules .git .idea
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE
 filterwarnings =
     ignore:inspect\.getargspec\(\) is deprecated:DeprecationWarning
+addopts =
+    -ra
+    --doctest-modules
+    --reuse-db
 
 [isort]
 default_section=THIRDPARTY


### PR DESCRIPTION
Add settings, tasks and launch configuration for attaching debugger and running tests with or without Docker in VSCode or Codium.

The included run-pytest script parses some options passed by the VSCode and makes them work nicely with the Docker container.

Add env.example file to improve visibility of the available .env vars.

Also set default pytest options in setup.cfg.