### PR TITLE
Docker pycache fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,6 @@ FROM python:3.8-slim-buster AS base
 
 EXPOSE 8000
 
-# Keeps Python from generating .pyc files in the container
-ENV PYTHONDONTWRITEBYTECODE=1
-
-# Turns off buffering for easier container logging
-ENV PYTHONUNBUFFERED=1
-
 # Install system dependencies
 RUN apt-get update  \
     && \
@@ -16,6 +10,12 @@ RUN apt-get update  \
       netcat \
       libpq-dev \
       build-essential
+
+# Keeps Python from generating .pyc files in the container
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Turns off buffering for easier container logging
+ENV PYTHONUNBUFFERED=1
 
 # Install pip requirements
 COPY requirements.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,12 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # Turns off buffering for easier container logging
 ENV PYTHONUNBUFFERED=1
 
+# Disable pip version check to speed up and avoid warnings
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+
 # Install pip requirements
 COPY requirements.txt .
-RUN python -m pip install -r requirements.txt
+RUN pip install -r requirements.txt
 
 WORKDIR /app
 


### PR DESCRIPTION
Avoid problems with non-compatible pyc files between the container
and the host checkout directory (which is mounted to /app in container).

This can also speed up imports in the container.

Also disable pip version check in the Dockerfile.