### PR TITLE
run-pytest: Wait for database and use TTY if available

### DIFF
--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -30,6 +30,8 @@ if [[ "$RUN_MODE" == "debug" ]]; then
     echo "Starting Django to port $PORT with debugpy on port $DEBUG_PORT..."
     python /tmp/debugpy --wait-for-client --listen 0.0.0.0:$DEBUG_PORT \
         manage.py runserver 0.0.0.0:$PORT --nothreading --noreload
+elif [[ "${1:0:1}" = "/" ]]; then
+    exec "$@"
 elif [[ -n "$1" ]]; then
     ./manage.py "$@"
 elif [[ "$RUN_MODE" == "production" ]]; then

--- a/run-pytest
+++ b/run-pytest
@@ -40,13 +40,21 @@ misc_opts=(
     "-o" "cache_dir=/tmp/pytest_cache"
 )
 
+docker_compose_exec=("docker-compose" "exec")
+if ! tty -s; then
+    docker_compose_exec+=("-T")  # If there is no TTY available, pass -T
+fi
+
+# Wait until the database is ready
+"${docker_compose_exec[@]}" -e RUN_MIGRATIONS=0 app ./docker-entrypoint /bin/true
+
 set +e
-docker-compose exec -T app pytest "${misc_opts[@]}" "${opts[@]}"
+"${docker_compose_exec[@]}" app pytest "${misc_opts[@]}" "${opts[@]}"
 exit_code=$?
 set -e
 
 if [[ -n "$xml_file" ]]; then
-    docker-compose exec -T app cat /tmp/pytest_junit.xml > "$xml_file"
+    "${docker_compose_exec[@]}" app cat /tmp/pytest_junit.xml > "$xml_file"
 fi
 
 exit $exit_code


### PR DESCRIPTION
Wait for the database to be up before starting pytest.

Also improve the TTY handling, because if the pytest is run with "docker-compose exec -T" in a terminal (TTY) and Ctrl+C is pressed, then the output of the pytest command is just detached from the terminal, but the command still continues to run in the container.  This is not good and therefore we should just pass "-T" when there is no TTY available (e.g. in the CI).