### PR TITLE
Dockerization: Add platform and change user uid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN pip install -r requirements.txt
 
 WORKDIR /app
 
-RUN adduser -u 5678 --disabled-password --gecos "" appuser
+RUN adduser -u 1000 --disabled-password --gecos "" appuser
 
 ENTRYPOINT ["./docker-entrypoint"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
   app:
+    platform: "linux/amd64"
     image: parkkihubi
     build:
       context: "."


### PR DESCRIPTION
Specify platform as "linux/amd64" for the app container in the docker-compose.yml, because that's what it's supposed to be and it won't even work on e.g. ARM based archs. (Some deps won't compile.)

Change the appuser uid to 1000, since that is very often the same uid as the developer's uid on a Linux host, which could avoid some problems when the source tree is mounted as a volume to the container and still being modified from the host.