### PR TITLE
Fix 0047_populate_permitarea_allowed_users migration (HPH-36)

### DIFF
--- a/parkings/migrations/0047_populate_permitarea_allowed_users.py
+++ b/parkings/migrations/0047_populate_permitarea_allowed_users.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(
-            populate_permitted_user_from_allowed_users,
+            populate_allowed_users_from_permitted_user,
             populate_permitted_user_from_allowed_users,
         ),
     ]


### PR DESCRIPTION
Fix the function name to run when executing the migration (in forward direction).