### PR TITLE
CI: Run apt-get update before install

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,7 +82,7 @@ jobs:
           python-version: "3.5"
 
       - name: Install GDAL
-        run: sudo apt-get install -y gdal-bin
+        run: sudo apt-get update && sudo apt-get install -y gdal-bin
         if: ${{ matrix.toxenv == 'sanitizer' }}
 
       - name: Install Tox and tox-gh-actions


### PR DESCRIPTION
The GitHub actions started to fail, because this step was unable to find the deb packages when installing the gdal-bin.  It seems that the problem was related to package lists not being up-to-date and adding "apt-get update" before the installation helps.